### PR TITLE
feat: chat:write.public scope + per-channel office location

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -159,11 +159,12 @@ Plans:
   3. App icon, directory screenshots, and YouTube demo video meet Slack's format requirements
   4. Bot is installed on 5+ active workspaces via beta rollout
   5. App is submitted to Slack App Directory and review process is initiated
-**Plans**: TBD
+**Plans**: 3 plans
 
 Plans:
-- [ ] 08-01: TBD
-- [ ] 08-02: TBD
+- [ ] 08-01-PLAN.md -- OAuth CSRF state hardening (MKT-01) + scope justification doc (MKT-02)
+- [ ] 08-02-PLAN.md -- Marketplace assets (icon, screenshots, demo video) + support@ alias setup (MKT-03/04/05, D-18)
+- [ ] 08-03-PLAN.md -- Beta rollout + submission gate script + App Directory submission (MKT-06/07)
 
 ## Progress
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 7 UI-SPEC approved
-last_updated: "2026-04-07T19:55:58.896Z"
+stopped_at: Phase 8 context gathered
+last_updated: "2026-04-15T16:03:39.576Z"
 last_activity: 2026-04-07 -- Phase 07 execution started
 progress:
   total_phases: 5
-  completed_phases: 3
+  completed_phases: 4
   total_plans: 10
-  completed_plans: 9
-  percent: 90
+  completed_plans: 10
+  percent: 100
 ---
 
 # Project State
@@ -87,6 +87,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-04-07T19:48:38.244Z
-Stopped at: Phase 7 UI-SPEC approved
-Resume file: .planning/phases/07-web-presence/07-UI-SPEC.md
+Last session: 2026-04-15T16:03:39.572Z
+Stopped at: Phase 8 context gathered
+Resume file: .planning/phases/08-marketplace-submission/08-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,7 +5,7 @@ milestone_name: milestone
 status: executing
 stopped_at: Phase 8 context gathered
 last_updated: "2026-04-15T16:03:39.576Z"
-last_activity: 2026-04-07 -- Phase 07 execution started
+last_activity: 2026-04-15 - Completed quick task 260415-p4t: chat:write.public scope and per-channel office location
 progress:
   total_phases: 5
   completed_phases: 4
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-06)
 Phase: 07 (web-presence) — EXECUTING
 Plan: 1 of 1
 Status: Executing Phase 07
-Last activity: 2026-04-07 -- Phase 07 execution started
+Last activity: 2026-04-15 - Completed quick task 260415-p4t: Add chat:write.public scope and per-channel office location selection
 
 Progress: [####......] 37%
 
@@ -84,6 +84,7 @@ None yet.
 |---|-------------|------|--------|-----------|
 | 260405-vqq | Set up blue-green Docker deployment infrastructure for LunchBot on home Ubuntu server | 2026-04-05 | da5f583 | [260405-vqq-set-up-blue-green-docker-deployment-infr](./quick/260405-vqq-set-up-blue-green-docker-deployment-infr/) |
 | 260406-abs | Fix deployment readiness: wsgi.py, Dockerfile CMD, migration step in deploy.sh | 2026-04-06 | 2962913 | [260406-abs-fix-deployment-readiness-wsgi-py-dockerf](./quick/260406-abs-fix-deployment-readiness-wsgi-py-dockerf/) |
+| 260415-p4t | Add chat:write.public scope and per-channel office location selection | 2026-04-15 | 6f46071 | [260415-p4t-add-chat-write-public-scope-and-per-chan](./quick/260415-p4t-add-chat-write-public-scope-and-per-chan/) |
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 8 context gathered
-last_updated: "2026-04-15T16:03:39.576Z"
-last_activity: 2026-04-15 - Completed quick task 260415-p4t: chat:write.public scope and per-channel office location
+stopped_at: Phase 8 planned (3 plans, verified)
+last_updated: "2026-04-15T16:22:11.072Z"
+last_activity: "2026-04-15 - Completed quick task 260415-p4t: Add chat:write.public scope and per-channel office location selection"
 progress:
   total_phases: 5
   completed_phases: 4
-  total_plans: 10
+  total_plans: 13
   completed_plans: 10
-  percent: 100
+  percent: 77
 ---
 
 # Project State
@@ -88,6 +88,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-04-15T16:03:39.572Z
-Stopped at: Phase 8 context gathered
-Resume file: .planning/phases/08-marketplace-submission/08-CONTEXT.md
+Last session: 2026-04-15T16:22:11.067Z
+Stopped at: Phase 8 planned (3 plans, verified)
+Resume file: .planning/phases/08-marketplace-submission/08-01-PLAN.md

--- a/.planning/phases/08-marketplace-submission/08-01-PLAN.md
+++ b/.planning/phases/08-marketplace-submission/08-01-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: 08-marketplace-submission
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - lunchbot/security/__init__.py
+  - lunchbot/security/oauth_state.py
+  - lunchbot/config.py
+  - lunchbot/blueprints/oauth.py
+  - tests/test_oauth_state.py
+  - tests/test_oauth.py
+  - tests/test_scopes_doc.py
+  - docs/slack-scopes.md
+  - requirements.txt
+  - requirements-dev.txt
+autonomous: true
+requirements: [MKT-01, MKT-02]
+must_haves:
+  truths:
+    - "/slack/install issues a signed, time-limited state parameter on the authorize redirect"
+    - "/slack/oauth_redirect rejects missing, tampered, expired, or wrong-secret state tokens and renders _error_page with structured log event oauth_state_invalid"
+    - "Valid state round-trip completes the existing token exchange unchanged"
+    - "docs/slack-scopes.md documents every scope in SCOPES and is kept in sync by an automated test"
+  artifacts:
+    - path: "lunchbot/security/oauth_state.py"
+      provides: "make_state_token / verify_state_token helpers"
+      contains: "URLSafeTimedSerializer"
+    - path: "lunchbot/blueprints/oauth.py"
+      provides: "install()/oauth_redirect() with state generation + verification"
+      contains: "verify_state_token"
+    - path: "docs/slack-scopes.md"
+      provides: "Scope justification per D-05"
+      contains: "commands"
+    - path: "tests/test_oauth_state.py"
+      provides: "Unit tests for state helper"
+    - path: "tests/test_scopes_doc.py"
+      provides: "Lint test syncing docs to SCOPES"
+  key_links:
+    - from: "lunchbot/blueprints/oauth.py install()"
+      to: "lunchbot/security/oauth_state.make_state_token"
+      via: "current_app.config['OAUTH_STATE_SECRET']"
+      pattern: "make_state_token\\("
+    - from: "lunchbot/blueprints/oauth.py oauth_redirect()"
+      to: "lunchbot/security/oauth_state.verify_state_token"
+      via: "request.args.get('state')"
+      pattern: "verify_state_token\\("
+    - from: "lunchbot/config.py"
+      to: "os.environ['OAUTH_STATE_SECRET']"
+      via: "app factory config loading"
+      pattern: "OAUTH_STATE_SECRET"
+---
+
+<objective>
+Harden the Slack OAuth install flow with a stateless HMAC-signed CSRF state parameter and publish the scope justification document required for marketplace submission.
+
+Purpose: MKT-01 is a hard rejection trigger — Slack requires a state parameter. MKT-02 needs a crisp per-scope justification that Slack reviewers can read without guessing. Both must ship together because the justification doc and the scope constant live at the same trust boundary.
+
+Output: Working CSRF-protected OAuth flow, complete unit + integration test coverage for state handling, and `docs/slack-scopes.md` kept in sync with `SCOPES` via a lint test.
+</objective>
+
+<execution_context>
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/08-marketplace-submission/08-CONTEXT.md
+@.planning/phases/08-marketplace-submission/08-RESEARCH.md
+@.planning/phases/08-marketplace-submission/08-VALIDATION.md
+@.planning/codebase/ARCHITECTURE.md
+@.planning/codebase/CONVENTIONS.md
+@lunchbot/blueprints/oauth.py
+@lunchbot/config.py
+
+<interfaces>
+From lunchbot/blueprints/oauth.py (existing, pre-change):
+
+```python
+SCOPES = 'commands,chat:write,users:read'
+
+def _redirect_uri() -> str: ...
+def encrypt_token(token, fernet_key) -> str: ...
+def decrypt_token(encrypted_token, fernet_key) -> str: ...
+
+@bp.route('/install')
+def install(): ...  # currently builds authorize URL with NO state
+
+@bp.route('/oauth_redirect')
+def oauth_redirect(): ...  # currently reads code + error, calls oauth_v2_access
+
+def _success_page() -> str: ...
+def _error_page() -> str: ...
+```
+
+New contract introduced by this plan:
+
+```python
+# lunchbot/security/oauth_state.py
+STATE_SALT: str = "slack-oauth-state-v1"
+STATE_MAX_AGE_SECONDS: int = 600  # 10 min per D-01
+
+def make_state_token(secret: str) -> str: ...
+def verify_state_token(token: str | None, secret: str) -> bool: ...
+```
+
+Config additions:
+
+```python
+# lunchbot/config.py
+OAUTH_STATE_SECRET: str  # loaded from os.environ, fail-fast per existing pattern
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Wave 0 test scaffolds + dev deps</name>
+  <files>tests/test_oauth_state.py, tests/test_scopes_doc.py, requirements.txt, requirements-dev.txt</files>
+  <behavior>
+    tests/test_oauth_state.py (6 cases — all MUST fail at this point because the module does not exist yet):
+    - test_valid_token_roundtrip: make_state_token -> verify_state_token returns True
+    - test_tampered_signature_rejected: flip last 4 chars -> verify returns False
+    - test_wrong_secret_rejected: verify with different secret returns False
+    - test_expired_token_rejected: freeze_time, tick 601s, verify returns False
+    - test_empty_token_rejected: verify("", secret) and verify(None, secret) return False
+    - test_malformed_token_rejected: verify("not-a-token", secret) returns False
+
+    tests/test_scopes_doc.py (2 cases — fail until docs/slack-scopes.md and the doc structure exist):
+    - test_scopes_doc_lists_all_code_scopes: every scope in `lunchbot.blueprints.oauth.SCOPES` has a matching `## \`<scope>\`` header in docs/slack-scopes.md
+    - test_scopes_doc_no_unknown_scopes: every `## \`<scope>\`` header in the doc maps to a scope in SCOPES (prevents drift)
+  </behavior>
+  <action>
+    1. Create `tests/test_oauth_state.py` with the 6 tests above. Import `from lunchbot.security.oauth_state import make_state_token, verify_state_token`. Use SECRET="test-secret-do-not-use-in-prod". For expired test, use `from freezegun import freeze_time` and `frozen.tick(delta=601)`.
+    2. Create `tests/test_scopes_doc.py` that reads `lunchbot.blueprints.oauth.SCOPES`, splits on comma, and parses `docs/slack-scopes.md` for lines matching the regex `^## \`([a-z_:.]+)\`` (exclude the "deliberately do NOT request" section by scanning only until a `## Scopes we deliberately` header). Assert two-way equality.
+    3. Verify `itsdangerous>=2.2.0` is explicitly pinned in `requirements.txt`. If only transitive, add the line (do NOT rely on Flask transitive per research A1).
+    4. Add `freezegun>=1.4` to `requirements-dev.txt` (create the file if it does not exist; if project uses `requirements.txt` for dev too, add there — detect by reading project).
+    5. Do NOT create `lunchbot/security/oauth_state.py` or `docs/slack-scopes.md` in this task — Task 2 implements them so the RED→GREEN cycle is visible.
+  </action>
+  <verify>
+    <automated>pip install -r requirements-dev.txt 2>/dev/null; pytest tests/test_oauth_state.py tests/test_scopes_doc.py -q 2>&1 | tail -20</automated>
+  </verify>
+  <done>All 8 new tests exist and FAIL with ModuleNotFoundError / FileNotFoundError (RED phase confirmed). freezegun importable. itsdangerous explicitly pinned.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement oauth_state helper, config secret, scope doc</name>
+  <files>lunchbot/security/__init__.py, lunchbot/security/oauth_state.py, lunchbot/config.py, docs/slack-scopes.md</files>
+  <behavior>
+    - After this task, the 8 tests from Task 1 MUST pass (GREEN phase).
+    - make_state_token returns a URL-safe string containing a 32-byte token_urlsafe nonce, signed via URLSafeTimedSerializer with salt STATE_SALT="slack-oauth-state-v1".
+    - verify_state_token returns True only for tokens produced with the same secret, within STATE_MAX_AGE_SECONDS=600, untampered. Catches SignatureExpired AND BadSignature; also handles None/"" / any other Exception from loads by returning False.
+    - lunchbot.config exposes OAUTH_STATE_SECRET loaded via `os.environ['OAUTH_STATE_SECRET']` at module load time, matching the fail-fast pattern used for FERNET_KEY.
+    - docs/slack-scopes.md contains `## \`commands\``, `## \`chat:write\``, `## \`users:read\`` sections (each one paragraph justifying against a user-visible feature per D-05), plus a "## Scopes we deliberately do NOT request" section.
+  </behavior>
+  <action>
+    1. Create `lunchbot/security/__init__.py` (empty, matches existing service/client empty-init convention per codebase CONVENTIONS.md).
+    2. Create `lunchbot/security/oauth_state.py` exactly matching the research canonical pattern (08-RESEARCH.md Pattern 1 / Code Examples section):
+       - module-level constants `STATE_SALT = "slack-oauth-state-v1"` and `STATE_MAX_AGE_SECONDS = 600`
+       - `make_state_token(secret: str) -> str`: instantiate `URLSafeTimedSerializer(secret_key=secret, salt=STATE_SALT)`, call `dumps({"n": secrets.token_urlsafe(32)})`
+       - `verify_state_token(token: str | None, secret: str) -> bool`: return False on empty/None; instantiate serializer; call `loads(token, max_age=STATE_MAX_AGE_SECONDS)`; return True; except `(SignatureExpired, BadSignature, Exception)` return False
+       - Do NOT hand-roll HMAC. Use itsdangerous per D-01 and research "don't hand-roll" table (chosen: URLSafeTimedSerializer per research alternatives-considered table).
+       - Using OAUTH_STATE_SECRET (not FERNET_KEY) per D-02 and research key-separation principle.
+    3. Edit `lunchbot/config.py`: add `OAUTH_STATE_SECRET = os.environ['OAUTH_STATE_SECRET']` next to FERNET_KEY, following existing fail-fast pattern. Do not make it optional. If config.py uses a Config class with from_env classmethod (check existing structure first), add the field in the same place FERNET_KEY lives.
+    4. Create `docs/slack-scopes.md` per D-05 using the exact template in 08-RESEARCH.md Pattern 2 (three scope sections + "Scopes we deliberately do NOT request" section). Each scope paragraph must name the specific LunchBot file that uses it (commands blueprint, poll_service, voter).
+    5. Run the Task 1 tests to confirm they all now pass (GREEN).
+  </action>
+  <verify>
+    <automated>pytest tests/test_oauth_state.py tests/test_scopes_doc.py -q</automated>
+  </verify>
+  <done>All 8 Task 1 tests pass. `lunchbot/security/oauth_state.py` exports make_state_token / verify_state_token. `docs/slack-scopes.md` exists with all three scope sections. `lunchbot/config.py` loads OAUTH_STATE_SECRET at import time.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Wire state into install() and oauth_redirect() + integration tests</name>
+  <files>lunchbot/blueprints/oauth.py, tests/test_oauth.py</files>
+  <behavior>
+    - `/slack/install` builds the Slack authorize URL with `state=<make_state_token(...)>` included via `urllib.parse.urlencode` (no f-string concatenation — research Pitfall 6).
+    - `/slack/oauth_redirect` calls `verify_state_token(request.args.get('state'), current_app.config['OAUTH_STATE_SECRET'])` BEFORE `WebClient().oauth_v2_access(...)`. On failure: logger.warning('oauth_state_invalid', has_state=bool(state)) and return `_error_page(), 400`. On success: existing token exchange code runs unchanged.
+    - Existing happy-path install → callback flow still works end-to-end (no regressions in existing tests/test_oauth.py).
+
+    New integration tests in tests/test_oauth.py:
+    - test_install_includes_state: GET /slack/install, follow location header, assert `state=` query param is present and non-empty
+    - test_callback_rejects_missing_state: GET /slack/oauth_redirect?code=abc (no state) → 400 + error page HTML, no call to oauth_v2_access
+    - test_callback_rejects_tampered_state: GET with state=make_state_token(SECRET)[:-4]+"XXXX" → 400 + error page
+    - test_callback_rejects_wrong_secret_state: GET with a state signed with a different secret → 400 + error page
+    - test_callback_accepts_valid_state: GET with state=make_state_token(app.config['OAUTH_STATE_SECRET']) + code=abc, mocked oauth_v2_access → 302 to /slack/setup?team_id=...
+    - All tests configure app with OAUTH_STATE_SECRET in test config fixture. Mock WebClient.oauth_v2_access via monkeypatch.
+  </behavior>
+  <action>
+    1. Read existing `tests/test_oauth.py` to understand the fixture pattern (app factory, config, WebClient mocking). Match the existing style.
+    2. Update test fixture / conftest to set `OAUTH_STATE_SECRET` to a known test value (e.g., "test-oauth-state-secret").
+    3. Edit `lunchbot/blueprints/oauth.py`:
+       - Add `from urllib.parse import urlencode` at top.
+       - Add `from lunchbot.security.oauth_state import make_state_token, verify_state_token`.
+       - Rewrite `install()` to build params dict including `state=make_state_token(current_app.config['OAUTH_STATE_SECRET'])` and call `redirect(f'https://slack.com/oauth/v2/authorize?{urlencode(params)}')`.
+       - In `oauth_redirect()`, right after parsing `code`/`error`, add `state = request.args.get('state')` and verification block: on invalid → `logger.warning('oauth_state_invalid', has_state=bool(state))` and `return _error_page(), 400`. Keep ordering: error/no-code check first, state check second, then token exchange. Per D-03.
+       - SCOPES constant is UNCHANGED (D-04 lock — still exactly 'commands,chat:write,users:read').
+    4. Add the 5 new integration tests in tests/test_oauth.py. Use pytest monkeypatch to replace WebClient.oauth_v2_access for the happy-path test.
+    5. Run full oauth test file to ensure no regressions in existing tests.
+  </action>
+  <verify>
+    <automated>pytest tests/test_oauth.py tests/test_oauth_state.py tests/test_scopes_doc.py -q</automated>
+  </verify>
+  <done>All tests pass. install() emits a state param. oauth_redirect() rejects missing/tampered/wrong-secret state with 400 + _error_page + structlog event. Valid state flows to existing token exchange. SCOPES constant unchanged.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Browser → /slack/install | Anonymous user initiates OAuth; attacker can forge install links |
+| Slack → /slack/oauth_redirect | Callback carries code + state; attacker-controlled query string |
+| App process → OAUTH_STATE_SECRET | Secret loaded from env at boot; never logged, never returned |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-08-01 | Tampering | /slack/install CSRF (attacker tricks victim into installing into attacker's workspace) | mitigate | HMAC-signed state token generated at /install and verified at /oauth_redirect via itsdangerous.URLSafeTimedSerializer (Task 3). Per D-01. |
+| T-08-02 | Tampering | State signature forgery | mitigate | itsdangerous timing-safe HMAC compare; no hand-rolled crypto (research "don't hand-roll" table). |
+| T-08-03 | Tampering | Expired state replay (attacker captures token, reuses later) | mitigate | 10-minute max_age enforced by `loads(..., max_age=STATE_MAX_AGE_SECONDS)`. Per D-01. |
+| T-08-04 | Tampering | In-window replay (true one-time-use) | accept | Stateless per D-02 — no server-side nonce store. 10-minute window is the accepted tradeoff; documented in research §Security Domain "Replay note". Matches Slack SDK default behavior. |
+| T-08-05 | Information Disclosure | OAUTH_STATE_SECRET reuse with FERNET_KEY (compromise of one breaks both boundaries) | mitigate | Dedicated `OAUTH_STATE_SECRET` env var loaded in lunchbot/config.py alongside FERNET_KEY (Task 2). Key-separation principle. |
+| T-08-06 | Information Disclosure | State token leaked in structlog events | mitigate | Log only `has_state=bool(state)` not the token itself (Task 3). |
+| T-08-07 | Spoofing | Attacker sends arbitrary state and code pairs | mitigate | verify_state_token runs BEFORE WebClient.oauth_v2_access — no token exchange occurs on unverified state (Task 3). |
+| T-08-08 | Denial of Service | Attacker floods /oauth_redirect with bad states | accept | Reverse-proxy rate limiting out of scope for this phase; state verification is O(1) HMAC verify (cheap). |
+| T-08-09 | Elevation of Privilege | Adding new scopes without review | mitigate | SCOPES constant unchanged (D-04 lock). tests/test_scopes_doc.py enforces bidirectional sync between SCOPES and docs/slack-scopes.md — any drift fails CI (Task 1 + Task 2). |
+</threat_model>
+
+<verification>
+- `pytest tests/test_oauth_state.py tests/test_oauth.py tests/test_scopes_doc.py -q` — all green
+- `pytest -q` — full suite green (no regressions)
+- Manual: grep `lunchbot/blueprints/oauth.py` confirms no f-string URL building in install()
+- Manual: confirm SCOPES constant is literally `'commands,chat:write,users:read'` (D-04)
+- Manual: confirm docs/slack-scopes.md has sections for all 3 scopes plus deliberately-not-requested list
+</verification>
+
+<success_criteria>
+1. OAuth install flow issues a signed state param; callback rejects missing/tampered/expired/wrong-secret tokens via _error_page + structured log (MKT-01)
+2. docs/slack-scopes.md documents all three scopes with justification tied to specific source files; lint test keeps doc in sync with SCOPES constant (MKT-02)
+3. All 8 Wave 0 tests + 5 integration tests pass
+4. No new scope added (D-04); no new DB table (D-02); _error_page reused (D-03); dedicated OAUTH_STATE_SECRET (research decision)
+5. Full pytest suite green
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08-marketplace-submission/08-01-SUMMARY.md`
+</output>

--- a/.planning/phases/08-marketplace-submission/08-02-PLAN.md
+++ b/.planning/phases/08-marketplace-submission/08-02-PLAN.md
@@ -1,0 +1,175 @@
+---
+phase: 08-marketplace-submission
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - assets/marketplace/icon-1024.png
+  - assets/marketplace/screenshots/01-install.png
+  - assets/marketplace/screenshots/02-poll.png
+  - assets/marketplace/screenshots/03-vote.png
+  - assets/marketplace/demo-script.md
+  - assets/marketplace/demo-checklist.md
+  - assets/marketplace/submission-copy.md
+  - tests/test_assets.py
+  - requirements-dev.txt
+  - docs/support-alias-setup.md
+autonomous: false
+requirements: [MKT-03, MKT-04, MKT-05]
+must_haves:
+  truths:
+    - "App icon exists at assets/marketplace/icon-1024.png at exactly 1024x1024"
+    - "At least 3 screenshots exist at exactly 1600x1000 (8:5 ratio)"
+    - "Demo video script + shot list forbid non-Slack surfaces and enforce 30-90s + closed captions"
+    - "submission-copy.md contains the public demo video URL, short desc, long desc, and category"
+    - "support@lunchbot.app alias receives mail forwarded to the developer inbox (or documented fallback domain if lunchbot.app is taken)"
+  artifacts:
+    - path: "assets/marketplace/icon-1024.png"
+      provides: "MKT-03 app icon"
+    - path: "assets/marketplace/screenshots/"
+      provides: "MKT-04 directory screenshots (min 3, 1600x1000)"
+    - path: "assets/marketplace/demo-script.md"
+      provides: "Narration script + shot list enforcing Slack-only shots"
+    - path: "assets/marketplace/submission-copy.md"
+      provides: "Slack-ready submission text + demo video URL"
+    - path: "tests/test_assets.py"
+      provides: "Pillow-based dimension lint for icon + screenshots"
+    - path: "docs/support-alias-setup.md"
+      provides: "Record of domain registrar, DNS, forwarding provider for support@ alias (D-18)"
+  key_links:
+    - from: "assets/marketplace/submission-copy.md"
+      to: "YouTube demo URL"
+      via: "public unlisted-or-public link with CC enabled"
+      pattern: "youtube\\.com/watch"
+    - from: "Phase 7 support page"
+      to: "support@lunchbot.app"
+      via: "domain + forwarding"
+      pattern: "support@lunchbot"
+---
+
+<objective>
+Produce every visual, textual, and infrastructure asset Slack App Directory requires for submission, AND establish the dedicated support email alias (D-18) so it propagates in time for submission.
+
+Purpose: MKT-03/04/05 are hard Slack requirements with exact pixel/length specs. Rejection risk is concentrated in subjective quality (icon), shot list (video), and copy tone. D-18 must start first in the phase because DNS propagation and email-forwarder verification take 24-48h.
+
+Output: Version-controlled `assets/marketplace/` bundle with icon, ≥3 screenshots, demo script, YouTube URL, and submission copy; automated dimension lint; live `support@lunchbot.app` alias (or documented fallback).
+
+Why parallel with 08-01: Zero file overlap. 08-01 touches code (lunchbot/, tests/test_oauth*). 08-02 touches assets/, docs/, and tests/test_assets.py. Both land in Wave 1.
+</objective>
+
+<execution_context>
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/08-marketplace-submission/08-CONTEXT.md
+@.planning/phases/08-marketplace-submission/08-RESEARCH.md
+@.planning/phases/08-marketplace-submission/08-VALIDATION.md
+</context>
+
+<tasks>
+
+<task type="checkpoint:human-action" gate="blocking">
+  <name>Task 1: Register lunchbot.app (or fallback) + set up support@ forwarding</name>
+  <files>docs/support-alias-setup.md</files>
+  <action>
+    Human-only step per D-18: domain registration requires payment entry on a registrar dashboard and DNS verification takes 24-48h. Run FIRST in the phase to maximize parallel wait time (research Pitfall 8). Steps:
+    1. Attempt to register `lunchbot.app` at Cloudflare Registrar (recommended — at-cost pricing, native DNS, free Email Routing). Confirm ownership.
+    2. If unavailable, pick fallback: `lunchbot.team`, `lunchbot.fyi`, or `getlunchbot.com` (research A8). Record chosen domain.
+    3. Configure email forwarding. Cloudflare Email Routing is free if DNS is on Cloudflare; ImprovMX is fallback. Create alias `support@<domain>` → developer inbox.
+    4. Send test email TO `support@<domain>` from an external account. Confirm delivery to developer inbox.
+    5. Create `docs/support-alias-setup.md` recording: chosen domain, registrar, DNS provider, forwarding provider, date registered, MX records configured, test-email timestamp and message-id.
+    6. If chosen domain differs from `lunchbot.app`, note it in setup doc as a change that must flow into Phase 7 support page and Plan 02 Task 2's submission-copy.md.
+    Resume signal: Type "support alias live" with chosen domain, or "blocker: <reason>".
+  </action>
+  <verify>
+    <automated>test -f docs/support-alias-setup.md && grep -qE "support@[a-z.]+" docs/support-alias-setup.md</automated>
+  </verify>
+  <done>Domain registered, support@&lt;domain&gt; alias receives forwarded mail (test email confirmed), docs/support-alias-setup.md committed with all registrar/DNS/forwarding details.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Asset dimension lint + scaffolding</name>
+  <files>tests/test_assets.py, requirements-dev.txt, assets/marketplace/demo-script.md, assets/marketplace/demo-checklist.md, assets/marketplace/submission-copy.md</files>
+  <action>
+    1. Add `Pillow>=10.0` to `requirements-dev.txt` (create section if missing). Pillow is the standard library for dimension checks and has no runtime impact.
+    2. Create `tests/test_assets.py` with Pillow-based tests (these fail until Task 3 produces the real assets — GREEN happens after checkpoint):
+       - test_icon_exists_and_dimensions: open `assets/marketplace/icon-1024.png`, assert `Image.open(...).size == (1024, 1024)` per MKT-03
+       - test_screenshots_exist_and_count: list files matching `assets/marketplace/screenshots/*.png`, assert `len(files) >= 3` per MKT-04
+       - test_screenshots_dimensions: for each screenshot, assert size == (1600, 1000) (exact 8:5 per Slack spec cited in research)
+       - test_screenshots_file_size: each file under 21 MB per Slack spec
+       - test_submission_copy_has_demo_url: parse `assets/marketplace/submission-copy.md` for a `youtube.com/watch?v=` URL (MKT-05) — skip (not fail) if file missing with a clear message, so this task's verify can succeed.
+       Use `pytest.skip` when files are absent at test time, flipping to `pytest.fail` only once files exist. Better pattern: parametrize to skip entire test if glob returns empty, with a message "Wave 0 placeholder — real assets produced in Task 3". This lets the structure land without blocking on artifact production.
+    3. Create `assets/marketplace/demo-script.md` with a shot list enforcing research Pitfall 5: "Every shot MUST be inside a real Slack workspace. No code editors, no browser chrome except for the install flow, no dashboards. Allowed surfaces: Slack desktop client, Slack mobile client, Slack install consent screen, LunchBot's own OAuth success page." Include a 4-beat 30-90s script: (1) /lunch command typed in channel, (2) poll appears with restaurants, (3) teammates vote with buttons, (4) poll shows winner after votes. Line for CC reminder: "Turn on closed captioning in YouTube upload settings per Slack MKT-05 requirement."
+    4. Create `assets/marketplace/demo-checklist.md`: pre-upload checklist — 30-90s length confirmed, CC enabled, ads disabled, video is public (not unlisted per Slack docs cited in research), URL is a `youtube.com/watch?v=` direct video link (not channel/playlist).
+    5. Create `assets/marketplace/submission-copy.md` scaffold with sections: Short description (≤140 chars), Long description, Category selection, Demo video URL (PLACEHOLDER — filled after video is uploaded in Task 3), Support contact (uses support@&lt;chosen-domain&gt; from Task 1 setup doc).
+    6. Ensure `assets/marketplace/` and `assets/marketplace/screenshots/` directories exist (create with `.gitkeep` if needed).
+  </action>
+  <verify>
+    <automated>pip install Pillow freezegun 2>/dev/null; pytest tests/test_assets.py -q</automated>
+  </verify>
+  <done>tests/test_assets.py runs and either passes (if assets already dropped in) or reports skips with clear "produced in Task 3" message. Scaffolds, shot list, and submission copy skeleton committed. Pillow pinned in dev deps.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Produce icon, screenshots, demo video, finalize submission copy</name>
+  <files>assets/marketplace/icon-1024.png, assets/marketplace/screenshots/01-install.png, assets/marketplace/screenshots/02-poll.png, assets/marketplace/screenshots/03-vote.png, assets/marketplace/submission-copy.md</files>
+  <action>
+    AI-assisted asset production per D-07/D-08/D-09. Claude cannot produce final binary assets — only lint, scaffolds, and checklist are automatable. Human steps:
+    1. Icon (MKT-03): Produce 1024x1024 PNG, food/lunch themed (sandwich/plate/fork — NOT speech bubble or Slack aubergine per research Pitfall 4). Save as `assets/marketplace/icon-1024.png`.
+    2. Screenshots (MKT-04): Produce ≥3 PNGs at exactly 1600x1000 (8:5), under 21 MB each, showing LunchBot inside a real Slack workspace only. Save as `assets/marketplace/screenshots/01-install.png`, `02-poll.png`, `03-vote.png`.
+    3. Demo video (MKT-05): Record 30-90s walkthrough following `assets/marketplace/demo-script.md` shot list. Upload to YouTube as PUBLIC (not unlisted) with closed captioning ENABLED and ads disabled. Copy the `youtube.com/watch?v=XXXX` URL.
+    4. Edit `assets/marketplace/submission-copy.md`: paste YouTube URL, fill short desc, long desc, category; replace placeholder support email with `support@<chosen-domain>` from Task 1 setup doc.
+    5. Visual review: no Slack-aubergine (#4A154B) dominance in icon; no non-Slack surfaces (code editor, dashboard) in any screenshot or video frame.
+    Resume signal: "assets complete" once all verify commands green + visual review passes. If video still rendering, "blocked on video" with ETA.
+  </action>
+  <verify>
+    <automated>pytest tests/test_assets.py -q</automated>
+  </verify>
+  <done>Icon + 3 screenshots at correct dimensions; YouTube demo URL (public, CC on, 30-90s) recorded in submission-copy.md; all tests/test_assets.py checks pass; visual review approved by user.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Public → support@lunchbot.app | Inbound email; spoofing and phishing risk on replies |
+| GitHub repo → assets/marketplace/ | Any committer can alter submission artifacts |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-08-10 | Spoofing | Email sent FROM support@lunchbot.app by attacker | mitigate | Configure SPF record at domain DNS restricting authorized senders; DKIM via forwarding provider (Cloudflare Email Routing / ImprovMX). Recorded in docs/support-alias-setup.md. |
+| T-08-11 | Information Disclosure | Personal developer email leaked via forwarding headers | accept | Forwarded-to address is not published anywhere; only alias appears publicly. Risk is low. |
+| T-08-12 | Tampering | Asset drift between repo and Slack submission (wrong version uploaded) | mitigate | Single source of truth in `assets/marketplace/`; submission-copy.md records exact file commit SHA used for upload. |
+| T-08-13 | Repudiation | Who approved the icon/screenshots | accept | Solo developer project; checkpoint Task 3 human-verify IS the approval record. |
+</threat_model>
+
+<verification>
+- `pytest tests/test_assets.py -q` — all green after Task 3
+- Visual review: icon food-themed, no Slack purple, screenshots all inside Slack, video 30-90s with CC
+- Test email to `support@<chosen-domain>` delivered
+- `assets/marketplace/submission-copy.md` contains real YouTube URL (not placeholder)
+</verification>
+
+<success_criteria>
+1. assets/marketplace/icon-1024.png exists at 1024x1024 (MKT-03)
+2. 3+ screenshots at exactly 1600x1000 in assets/marketplace/screenshots/ (MKT-04)
+3. Public YouTube demo video URL (30-90s, CC on) recorded in submission-copy.md (MKT-05)
+4. support@<chosen-domain> alias live and tested (D-18, enables MKT-07 submission)
+5. tests/test_assets.py green, Pillow pinned in dev deps
+6. docs/support-alias-setup.md records registrar/DNS/forwarder decisions
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08-marketplace-submission/08-02-SUMMARY.md`
+</output>

--- a/.planning/phases/08-marketplace-submission/08-03-PLAN.md
+++ b/.planning/phases/08-marketplace-submission/08-03-PLAN.md
@@ -1,0 +1,214 @@
+---
+phase: 08-marketplace-submission
+plan: 03
+type: execute
+wave: 2
+depends_on: [08-01, 08-02]
+files_modified:
+  - scripts/submission_gate.py
+  - tests/test_submission_gate.py
+  - docs/beta-tracker.md
+  - docs/post-install-welcome-audit.md
+  - assets/marketplace/submission-checklist.md
+autonomous: false
+requirements: [MKT-06, MKT-07]
+must_haves:
+  truths:
+    - "scripts/submission_gate.py reports all of D-13..D-17 green before submission is allowed"
+    - "Beta rollout has 5+ workspaces each with ≥1 completed poll recorded in the database (MKT-06)"
+    - "Phase 5 post-install welcome coverage is audited and, if missing, patched via a follow-up task before submission (research A7)"
+    - "LunchBot submission is filed in the Slack App Directory dashboard with screenshot confirmation (MKT-07)"
+  artifacts:
+    - path: "scripts/submission_gate.py"
+      provides: "Automated D-13..D-17 gate enforcement"
+    - path: "tests/test_submission_gate.py"
+      provides: "Unit tests for the gate script"
+    - path: "docs/beta-tracker.md"
+      provides: "Beta workspace contact log + P0/P1 issue tracker (D-12, D-14, D-15)"
+    - path: "docs/post-install-welcome-audit.md"
+      provides: "Verification that Phase 5 App Home welcome fires on workspace install (research A7 / Pitfall 2)"
+    - path: "assets/marketplace/submission-checklist.md"
+      provides: "Step-by-step walkthrough of the Slack App Directory submission portal"
+  key_links:
+    - from: "scripts/submission_gate.py"
+      to: "PostgreSQL workspaces + polls tables"
+      via: "SQL query (workspace count with completed poll)"
+      pattern: "SELECT.*FROM workspaces"
+    - from: "scripts/submission_gate.py"
+      to: "Phase 6 uptime/alert stack"
+      via: "Prometheus/Grafana API or log inspection"
+      pattern: "prometheus|grafana|uptime"
+---
+
+<objective>
+Drive the private beta rollout, enforce the D-13..D-17 submission gate with an automated check script, and file the App Directory submission.
+
+Purpose: Slack review takes up to 10 weeks and a rejection resets the clock (research Pitfall 7). The gate is not hygiene — it is the difference between a 10-week launch and a 20-week launch. This plan also closes research Open Question 2 (Phase 5 post-install welcome coverage per A7), because a missing welcome is a top rejection trigger (Pitfall 2).
+
+Output: Working gate script with tests, filled beta tracker, post-install welcome audit (+ patch if required), final submission with screenshot confirmation.
+
+Wave 2 because the gate requires Plan 01 (MKT-01 fix shipped — D-13 uptime must reflect the hardened build) and Plan 02 (support alias + assets complete — D-17 pages live, submission copy populated).
+</objective>
+
+<execution_context>
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/08-marketplace-submission/08-CONTEXT.md
+@.planning/phases/08-marketplace-submission/08-RESEARCH.md
+@.planning/phases/08-marketplace-submission/08-VALIDATION.md
+@.planning/phases/08-marketplace-submission/08-01-PLAN.md
+@.planning/phases/08-marketplace-submission/08-02-PLAN.md
+
+Prior plans:
+- 08-01 ships MKT-01 (OAuth state) and MKT-02 (scope doc) — required for D-13 (uptime on hardened build) and as submission artifacts
+- 08-02 ships MKT-03/04/05 assets and the support@ alias — required for D-17 and submission form fields
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Submission gate script + tests + post-install welcome audit</name>
+  <files>scripts/submission_gate.py, tests/test_submission_gate.py, docs/beta-tracker.md, docs/post-install-welcome-audit.md</files>
+  <behavior>
+    scripts/submission_gate.py — CLI script that runs all 5 gate checks and exits non-zero on any failure, with human-readable `[PASS]` / `[FAIL]` / `[WARN]` output per check. Supports `--check &lt;name&gt;` to run a single check and `--json` for machine output.
+
+    Checks implemented (per D-13..D-17 and research Pattern 3):
+    - `uptime`: D-13 — query Phase 6 Prometheus/Grafana (or read a locally-cached status file if API unavailable) for 7 consecutive days green. Implementation note: read `PROMETHEUS_URL` from env; query `up{job="lunchbot"}` over 7 days; PASS if no downtime sample. If env var missing, print WARN and require manual confirmation via `--confirm-manual uptime` flag.
+    - `beta_workspaces`: D-14 — connect to PostgreSQL using existing `lunchbot.config` DATABASE_URL; SQL: `SELECT COUNT(*) FROM workspaces w WHERE w.deleted_at IS NULL AND EXISTS (SELECT 1 FROM polls p WHERE p.workspace_id = w.id)` (adjust to actual schema — inspect via existing db_client to confirm column names). PASS if count >= 5.
+    - `p0_p1_issues`: D-15 — parse `docs/beta-tracker.md` for a `## Open P0/P1 Issues` section; PASS if section is empty or reads "None".
+    - `alert_test`: D-16 — look for a file `docs/alert-test-log.md` containing a dated entry within the last 30 days OR a synthetic-downtime alert in the Phase 6 alert history. PASS if recent alert-test record exists.
+    - `web_pages`: D-17 — HEAD-check landing, privacy, support URLs (read from env or config); PASS if all 3 return 200 AND git log shows initial commit of Phase 7 files >= 7 days ago.
+
+    tests/test_submission_gate.py — unit tests with all external dependencies mocked:
+    - test_gate_all_pass: monkeypatch all 5 check functions to return PASS; assert overall exit 0
+    - test_gate_uptime_fails: PASS others, FAIL uptime; assert exit nonzero and "[FAIL] uptime" in stdout
+    - test_gate_beta_fails: monkeypatch DB count to return 4; assert "[FAIL] beta_workspaces" and exit nonzero
+    - test_gate_p0_issues_parse: write a fake beta-tracker.md with "## Open P0/P1 Issues\n- ISSUE-1: outage"; assert FAIL. Empty list -> PASS.
+    - test_gate_json_output: invoke with --json; assert stdout is valid JSON with keys per check
+    - test_gate_single_check: invoke with --check beta_workspaces; assert only beta_workspaces runs
+  </behavior>
+  <action>
+    1. Create `scripts/submission_gate.py` with the 5 gate-check functions above. Use `argparse` for CLI. Use existing `lunchbot.config` / `lunchbot.db_client` for DB access — do NOT reinvent connection logic. Use `requests` for HEAD checks (already a dep).
+    2. Each check returns a `CheckResult` dataclass: `{name: str, status: Literal["PASS","FAIL","WARN"], message: str}`. Main function aggregates results and exits `0` only if every status is PASS.
+    3. Create `tests/test_submission_gate.py` with the 6 tests above. Mock DB via `unittest.mock.patch` on `lunchbot.db_client.fetch_one`. Mock HEAD via `requests_mock` or `unittest.mock.patch` on `requests.head`.
+    4. Create `docs/beta-tracker.md` with sections: `## Beta Workspaces` (table: workspace name, contact, install date, completed poll y/n, feedback notes), `## Open P0/P1 Issues` (empty list initially — MUST be empty for gate to pass), `## Closed Issues` (P0/P1 only; log). Per research "Don't Hand-Roll" — markdown table beats a custom tracker for 5 workspaces (D-12).
+    5. Create `docs/post-install-welcome-audit.md`: audit Phase 5's App Home handler to confirm a welcome message fires on the OAuth success path, not only on `app_home_opened` (research A7 / Open Question 2 / Pitfall 2). Document findings:
+       - Read `.planning/phases/05-poll-automation/05-03-PLAN.md` and matching `05-03-SUMMARY.md`
+       - Grep for `app_home_opened` in `lunchbot/blueprints/` and `lunchbot/service/`
+       - Check whether `oauth_redirect()` (in lunchbot/blueprints/oauth.py, AFTER Plan 01 changes) invokes a welcome-message emitter after `save_workspace(...)` and before the redirect to `/slack/setup`
+       - Document one of three outcomes:
+         a) PASS — welcome message already fires on install (record file + line)
+         b) FAIL — need to patch: add a `post_install_welcome(team_id, bot_token)` call in `oauth_redirect()` that uses `slack_sdk.WebClient(token=bot_token).chat_postMessage(...)` to the app_home or to the first available channel. Raise a follow-up fix task in Task 3 of this plan before submission.
+         c) UNKNOWN — blocked; escalate to user.
+    6. Run the new tests.
+  </action>
+  <verify>
+    <automated>pytest tests/test_submission_gate.py -q</automated>
+  </verify>
+  <done>
+    - scripts/submission_gate.py exists, runnable via `python scripts/submission_gate.py --help`
+    - All 6 tests pass
+    - docs/beta-tracker.md scaffold committed with empty P0/P1 section
+    - docs/post-install-welcome-audit.md committed with PASS/FAIL/UNKNOWN outcome. If FAIL, outcome section explicitly lists the patch needed and confirms Task 3 will block on it.
+  </done>
+</task>
+
+<task type="checkpoint:human-action" gate="blocking">
+  <name>Task 2: Drive private beta rollout to 5+ workspaces</name>
+  <files>docs/beta-tracker.md</files>
+  <action>
+    Private beta outreach per D-10/D-11/D-12. Human-only: requires personal outreach, coordination, and waiting for external users to install + complete a poll. No CLI/API can drive this. Steps:
+    1. Reach out to personal contacts with Slack workspaces (D-10 — NO public posting to IndieHackers/Reddit/HN/ProductHunt; explicitly deferred).
+    2. Share the standard `/slack/install` URL (D-11 — no separate private listing).
+    3. For each workspace that installs, record in `docs/beta-tracker.md` under `## Beta Workspaces`: name, contact, install date.
+    4. Coach each workspace through running one full `/lunch` poll with real voters.
+    5. Update beta-tracker entry with "completed poll: yes" once verified (DB query or screenshot).
+    6. Collect feedback informally via DM/email (D-12); log issues in `## Open P0/P1 Issues` or `## Closed Issues`. P0 = bot broken. P1 = major feature broken. Anything lower does NOT block submission.
+    7. Run `python scripts/submission_gate.py --check beta_workspaces` periodically. Goal: PASS (count >= 5).
+    8. If Task 1's post-install welcome audit returned FAIL, patch the welcome behavior before Task 3 (tiny: single `chat_postMessage` call in oauth_redirect success branch). Log patch in beta-tracker.md.
+    9. D-15: resolve every P0/P1 before Task 3 — Slack review slots are precious (research Pitfall 7).
+    Resume signal: "beta gate green" once gate check passes AND P0/P1 section empty AND any welcome patch merged. Include workspace count and beta-tracker.md commit link.
+  </action>
+  <verify>
+    <automated>python scripts/submission_gate.py --check beta_workspaces --check p0_p1_issues</automated>
+  </verify>
+  <done>5+ beta workspaces installed with completed polls (D-14); zero open P0/P1 (D-15); docs/beta-tracker.md reflects state; welcome-message patch merged if Task 1 audit required it.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Run full submission gate + file Slack App Directory submission</name>
+  <files>assets/marketplace/submission-checklist.md, assets/marketplace/submission-confirmation.png, .planning/STATE.md</files>
+  <action>
+    Final end-to-end gate run + Slack App Directory submission (MKT-07). Form is a Slack-hosted authenticated web portal at "Manage Distribution → Submit to the Slack App Directory"; form-filling is human-only. Steps:
+    1. Run `python scripts/submission_gate.py` — MUST print PASS for ALL 5 checks (uptime, beta_workspaces, p0_p1_issues, alert_test, web_pages). No WARNs accepted. If a WARN is due to missing env var, fill the env var OR pass `--confirm-manual <name>` only with documented evidence in submission-checklist.md.
+    2. Run `pytest -q` — MUST be fully green. Confirms Plans 01/02/03 tests all pass together.
+    3. Create `assets/marketplace/submission-checklist.md` for audit trail with:
+       - Git commit SHA at submission time
+       - Gate run output (paste PASS evidence)
+       - Timestamp + message-id of fresh test email to support@&lt;domain&gt;
+       - SCOPES constant re-grep result (must equal `commands,chat:write,users:read` — D-04 final lock)
+       - Cross-check: docs/slack-scopes.md vs Phase 7 privacy policy naming actual fields (research Pitfall 3)
+       - Phase 7 support page confirmed to show support@&lt;domain&gt;
+       - Icon visual re-review (Pitfall 4: no aubergine, food theme)
+       - Demo video re-watch (Pitfall 5: Slack-only surfaces)
+    4. Open https://api.slack.com/apps/&lt;lunchbot-app-id&gt; → "Manage Distribution" → ensure distribution enabled → "Submit to the Slack App Directory".
+    5. Fill submission form from `assets/marketplace/submission-copy.md`: short desc, long desc, category, upload icon-1024.png, upload 3 screenshots, paste YouTube demo URL, set support contact to support@&lt;domain&gt;, paste privacy policy + support page URLs from Phase 7, paste docs/slack-scopes.md content into per-scope justification fields, confirm scope list is exactly `commands`, `chat:write`, `users:read`.
+    6. Click "Submit for Review". Screenshot confirmation page → save as `assets/marketplace/submission-confirmation.png`. Commit.
+    7. Update `docs/beta-tracker.md` with submission date + expected review window (10 business days preliminary + up to 10 weeks functional per research). Update `.planning/STATE.md` Blockers/Concerns → "awaiting Slack review".
+    Resume signal: "submitted" with any Slack submission reference ID. If gate fails, say "gate failing: <checks>" and loop back to Task 2 — do NOT submit until green (research Pitfall 7: rejection resets the 10-week clock).
+  </action>
+  <verify>
+    <automated>python scripts/submission_gate.py && pytest -q && test -f assets/marketplace/submission-confirmation.png</automated>
+  </verify>
+  <done>All 5 gate checks PASS; full pytest suite green; submission-confirmation.png committed; STATE.md updated to "awaiting Slack review"; MKT-07 complete.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| submission_gate.py → PostgreSQL | Read-only query on workspaces/polls; must not leak data |
+| submission_gate.py → Phase 6 Prometheus | Outbound HTTP to observability stack |
+| Developer → Slack App Directory portal | Authenticated web session; manual form submission |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-08-14 | Tampering | Gate bypass — submitting without running the check | mitigate | Task 3 checkpoint explicitly requires pasting gate output into submission-checklist.md. Human-verify step blocks advance. |
+| T-08-15 | Tampering | Beta tracker forged "completed poll" status | accept | Solo dev project; gate script validates against DB, not the markdown. beta_workspaces check queries polls table directly. |
+| T-08-16 | Information Disclosure | submission_gate.py logs workspace names | mitigate | Gate output uses counts, not workspace names by default. `--json` mode for machine parsing does not expose PII. |
+| T-08-17 | Elevation of Privilege | Submission form requesting extra scopes vs SCOPES constant | mitigate | Task 3 step 5 re-greps SCOPES constant before form submission as an explicit check. D-04 lock. |
+| T-08-18 | Repudiation | Dispute over what was submitted | mitigate | submission-confirmation.png + git SHA + gate output all committed for audit trail. |
+| T-08-19 | Denial of Service | Rejection resets 10-week clock | mitigate | Gate D-13..D-17 enforced before submission (research Pitfall 7). Post-install welcome audit (Task 1) closes the #2 top rejection trigger (Pitfall 2). |
+</threat_model>
+
+<verification>
+- `pytest tests/test_submission_gate.py -q` — gate script tests green
+- `pytest -q` — full suite green (regression check across all 3 plans)
+- `python scripts/submission_gate.py` — all 5 checks PASS
+- `assets/marketplace/submission-confirmation.png` committed
+- `.planning/STATE.md` updated: "awaiting Slack review"
+</verification>
+
+<success_criteria>
+1. submission_gate.py enforces D-13..D-17 with automated checks + tests (MKT-07 gate)
+2. 5+ beta workspaces each completed a poll; zero open P0/P1 (MKT-06, D-14, D-15)
+3. Post-install welcome audit complete; patched if needed (research A7, Pitfall 2)
+4. Slack App Directory submission filed with screenshot confirmation (MKT-07)
+5. Full test suite green end-to-end across Plans 01/02/03
+6. SCOPES constant remains `commands,chat:write,users:read` (D-04 final lock verified at submission time)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08-marketplace-submission/08-03-SUMMARY.md`
+</output>

--- a/.planning/phases/08-marketplace-submission/08-CONTEXT.md
+++ b/.planning/phases/08-marketplace-submission/08-CONTEXT.md
@@ -1,0 +1,126 @@
+# Phase 8: Marketplace Submission - Context
+
+**Gathered:** 2026-04-15
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+LunchBot passes Slack App Directory review and is listed publicly. In scope: OAuth CSRF hardening, scope audit, app assets (icon, screenshots, demo video), private beta rollout to 5+ workspaces, and App Directory submission. Out of scope: post-launch growth, paid billing, new bot features.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### OAuth CSRF state (MKT-01)
+- **D-01:** Use HMAC-signed stateless state token. The `/slack/install` endpoint generates a token containing a random nonce + timestamp, signed with a server secret. The `/slack/oauth_redirect` callback verifies the signature and rejects expired (>10 min) or reused tokens.
+- **D-02:** No database table for state — keep it stateless. Reuse `FERNET_KEY` or introduce a separate `OAUTH_STATE_SECRET` env var (planner decides).
+- **D-03:** On signature/expiry failure, render the existing `_error_page()` with a clear message and log structured event `oauth_state_invalid`.
+
+### Scope audit (MKT-02)
+- **D-04:** Keep exactly the current three scopes: `commands`, `chat:write`, `users:read`. No additions. Minimal surface = fastest review.
+- **D-05:** Produce a written justification document (one paragraph per scope) as part of submission artifacts. Lives at `docs/slack-scopes.md`.
+- **D-06:** Any feature request that needs a new scope is deferred to a post-launch phase.
+
+### App assets (MKT-03, MKT-04, MKT-05)
+- **D-07:** AI-assisted production. Icon and screenshots designed in Figma with AI image tools (Midjourney/Claude) for visual concepts; user finalizes.
+- **D-08:** Demo video recorded by the user with voiceover narration. Target 30-90 seconds, closed captions required.
+- **D-09:** Assets stored under `assets/marketplace/` in the repo so they are version-controlled alongside submission text.
+
+### Beta rollout (MKT-06)
+- **D-10:** Private beta only — direct outreach to known workspaces and personal contacts. No public posting (IndieHackers, Reddit, HN, ProductHunt) in this phase.
+- **D-11:** Distribute via the standard `/slack/install` link; no separate private listing.
+- **D-12:** Collect feedback informally (DM / email). No in-app feedback widget required.
+
+### Submission gate criteria (MKT-07)
+Submission may only be initiated when ALL of the following are true:
+- **D-13:** Uptime monitoring has reported 7+ consecutive days green (Phase 6 stack).
+- **D-14:** 5+ active beta workspaces installed, each has completed at least one poll end-to-end.
+- **D-15:** Zero open P0 or P1 issues from beta feedback.
+- **D-16:** Phase 6 alerting verified in a test (synthetic downtime triggers notification).
+- **D-17:** Landing page, privacy policy, and support page have been live for 7+ days (from Phase 7 go-live).
+
+### Review contact (MKT listing)
+- **D-18:** Dedicated alias `support@lunchbot.app` used for Slack review correspondence and public support page. Requires domain registration + forwarding setup as first task in this phase.
+- **D-19:** Inherits the Phase 7 commitment of 2-business-day response SLA.
+
+### Claude's Discretion
+- Exact token format for OAuth state (itsdangerous TimestampSigner vs hand-rolled HMAC)
+- Specific Figma template and AI prompts for asset generation
+- Beta feedback collection template / tracker format
+- Domain registrar and forwarding provider for support alias
+- Docstring style for scope justification doc
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Requirements
+- `.planning/REQUIREMENTS.md` §MKT-01–MKT-07 — Full text of each marketplace requirement and acceptance criteria
+- `.planning/ROADMAP.md` — Phase 8 scope, dependencies on Phases 5/6/7
+
+### Prior phase context
+- `.planning/phases/02-multi-tenancy/02-CONTEXT.md` — OAuth V2 flow decisions, Fernet token encryption
+- `.planning/phases/06-observability/` — Uptime monitoring, alerting stack referenced by D-13/D-16
+- `.planning/phases/07-web-presence/07-CONTEXT.md` — Landing/privacy/support pages referenced by D-17
+
+### Codebase maps
+- `.planning/codebase/ARCHITECTURE.md` — Blueprint layout, OAuth blueprint location
+- `.planning/codebase/CONVENTIONS.md` — Logging, error handling, config patterns
+
+### External (Slack)
+- Slack App Directory review guidelines (must be fetched during research phase — not local)
+- Slack OAuth V2 state parameter docs (must be fetched during research phase)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `lunchbot/blueprints/oauth.py:39-46` — `install()` currently redirects without `state`; injection point for D-01.
+- `lunchbot/blueprints/oauth.py:49-92` — `oauth_redirect()` callback; state verification lands before `oauth_v2_access` call.
+- `lunchbot/blueprints/oauth.py:27-36` — Existing Fernet encrypt/decrypt helpers; pattern to mirror for HMAC signing if chosen.
+- `lunchbot/blueprints/oauth.py:119-137` — `_error_page()` helper already renders submission-ready error HTML — reuse for state failures.
+- `structlog` logger pattern (`oauth.py:14`) — use for `oauth_state_invalid` and related events per Phase 6.
+
+### Established Patterns
+- Config via `current_app.config[...]` with env-var loading at app factory time — add `OAUTH_STATE_SECRET` here if introduced.
+- Blueprints are thin; logic stays in `blueprints/`. State generation/verification can live in a small helper module `lunchbot/security/oauth_state.py`.
+- Tests co-located in `tests/test_oauth.py` — existing harness covers install + callback; extend for state happy path, tampered signature, expired token, replay.
+
+### Integration Points
+- Phase 6 observability: new log events must carry workspace/request IDs where available.
+- Phase 7 support page contact: update to `support@lunchbot.app` once alias is live (D-18).
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- OAuth state must be stateless — no new DB table. User explicitly preferred 1a.
+- Scope list is frozen at three. Any temptation to add scopes for DX goes to a post-launch backlog.
+- Beta must stay private — no broad public channels before Slack approves the listing.
+- Support alias must be a dedicated domain address, not the developer's personal gmail.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Public launch channels (IndieHackers, Reddit r/Slack, HN Show, ProductHunt) — post-launch growth phase.
+- Adding `chat:write.public` / `im:write` scopes — revisit only if beta feedback demands it, and only post-approval.
+- In-app feedback widget — out of scope; email/DM is enough for a 5-workspace beta.
+- Paid tier / Stripe billing — already deferred per project decision.
+- Scheduled post-launch growth experiments.
+
+</deferred>
+
+---
+
+*Phase: 08-marketplace-submission*
+*Context gathered: 2026-04-15*

--- a/.planning/phases/08-marketplace-submission/08-DISCUSSION-LOG.md
+++ b/.planning/phases/08-marketplace-submission/08-DISCUSSION-LOG.md
@@ -1,0 +1,41 @@
+# Phase 8: Marketplace Submission - Discussion Log
+
+**Date:** 2026-04-15
+**Phase:** 08-marketplace-submission
+**Mode:** discuss (interactive, condensed)
+
+## Gray Areas Presented
+
+1. OAuth state storage mechanism
+2. Scope audit outcome
+3. App assets production approach
+4. Beta rollout channel
+5. Submission gate criteria
+6. Review/support contact
+
+## User Selections
+
+| # | Area | User Choice | Decision ID |
+|---|------|-------------|-------------|
+| 1 | OAuth state storage | a — HMAC-signed stateless token | D-01, D-02, D-03 |
+| 2 | Scope audit | a — Keep current 3 scopes | D-04, D-05, D-06 |
+| 3 | App assets | b — AI-assisted (Figma + AI tools) | D-07, D-08, D-09 |
+| 4 | Beta rollout | a — Private only, direct outreach | D-10, D-11, D-12 |
+| 5 | Submission gate | a+b+c+d+e (all gate criteria apply) | D-13–D-17 |
+| 6 | Review contact | b — Dedicated `support@lunchbot.app` alias | D-18, D-19 |
+
+## Notes
+
+- User annotated choice 4 with "for now" — private beta is a Phase 8 constraint, public channels explicitly deferred to post-launch.
+- No corrections; all six options taken as-is.
+- Scope creep check: no new capabilities proposed. All discussion stayed inside ROADMAP Phase 8 boundary.
+
+## Codebase Evidence Cited
+
+- `lunchbot/blueprints/oauth.py:39-46` — confirmed MKT-01 gap (no state param on install redirect)
+- `lunchbot/blueprints/oauth.py:18` — current scopes hardcoded as `commands, chat:write, users:read`
+- `.planning/codebase/ARCHITECTURE.md`, `CONVENTIONS.md` — blueprint and logging patterns
+
+## External Research
+
+None performed in this step. Slack App Directory guidelines and OAuth V2 state docs flagged as research targets for `/gsd-plan-phase 8`.

--- a/.planning/phases/08-marketplace-submission/08-RESEARCH.md
+++ b/.planning/phases/08-marketplace-submission/08-RESEARCH.md
@@ -1,0 +1,577 @@
+# Phase 8: Marketplace Submission - Research
+
+**Researched:** 2026-04-15
+**Domain:** Slack App Directory submission — OAuth hardening, compliance assets, private beta, review process
+**Confidence:** HIGH (OAuth implementation), HIGH (Slack requirements), MEDIUM (review timeline — moving target)
+
+## Summary
+
+Phase 8 is a compliance-and-packaging phase, not a feature phase. The single piece of real code is adding a CSRF `state` parameter to the existing OAuth blueprint (`lunchbot/blueprints/oauth.py`). Everything else is producing artifacts (icon, screenshots, demo video, scope justification doc, support alias) and driving a gated rollout/submission workflow.
+
+The OAuth state fix is textbook: Slack [CITED: docs.slack.dev] explicitly requires a `state` parameter for CSRF prevention, and stateless HMAC-signed tokens via `itsdangerous.URLSafeTimedSerializer` are the standard Python pattern — battle-tested, part of Flask's own dependency tree (Flask already depends on itsdangerous for session cookies), supports max-age expiry out of the box, URL-safe, and rejects tampered or expired tokens on `loads()`.
+
+Slack's review is slow and strict. Preliminary feedback takes up to 10 business days; functional review up to 10 weeks [CITED: docs.slack.dev/slack-marketplace/slack-marketplace-review-guide]. Rejections are almost always triggered by (1) unnecessary scopes, (2) missing/weak App Home, (3) missing install welcome message, (4) inconsistent branding, (5) vague data handling in privacy policy. LunchBot's three-scope surface (`commands`, `chat:write`, `users:read`) is minimal and defensible — the risk is not scope creep but presentation: justification doc must be crisp and map each scope to a specific user-visible feature.
+
+**Primary recommendation:** Ship OAuth state via `itsdangerous.URLSafeTimedSerializer` with a dedicated `OAUTH_STATE_SECRET` env var (not FERNET_KEY — separation of concerns, different cryptographic purpose). Build a submission artifact bundle under `assets/marketplace/` and `docs/slack-scopes.md`. Treat the submission gate (D-13 through D-17) as a hard blocker enforced by a checklist script, not eyeballed.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**OAuth CSRF state (MKT-01)**
+- **D-01:** Use HMAC-signed stateless state token. The `/slack/install` endpoint generates a token containing a random nonce + timestamp, signed with a server secret. The `/slack/oauth_redirect` callback verifies the signature and rejects expired (>10 min) or reused tokens.
+- **D-02:** No database table for state — keep it stateless. Reuse `FERNET_KEY` or introduce a separate `OAUTH_STATE_SECRET` env var (planner decides).
+- **D-03:** On signature/expiry failure, render the existing `_error_page()` with a clear message and log structured event `oauth_state_invalid`.
+
+**Scope audit (MKT-02)**
+- **D-04:** Keep exactly the current three scopes: `commands`, `chat:write`, `users:read`. No additions. Minimal surface = fastest review.
+- **D-05:** Produce a written justification document (one paragraph per scope) as part of submission artifacts. Lives at `docs/slack-scopes.md`.
+- **D-06:** Any feature request that needs a new scope is deferred to a post-launch phase.
+
+**App assets (MKT-03, MKT-04, MKT-05)**
+- **D-07:** AI-assisted production. Icon and screenshots designed in Figma with AI image tools (Midjourney/Claude) for visual concepts; user finalizes.
+- **D-08:** Demo video recorded by the user with voiceover narration. Target 30-90 seconds, closed captions required.
+- **D-09:** Assets stored under `assets/marketplace/` in the repo so they are version-controlled alongside submission text.
+
+**Beta rollout (MKT-06)**
+- **D-10:** Private beta only — direct outreach to known workspaces and personal contacts. No public posting (IndieHackers, Reddit, HN, ProductHunt) in this phase.
+- **D-11:** Distribute via the standard `/slack/install` link; no separate private listing.
+- **D-12:** Collect feedback informally (DM / email). No in-app feedback widget required.
+
+**Submission gate (MKT-07)** — ALL must be true before submitting:
+- **D-13:** Uptime monitoring has reported 7+ consecutive days green.
+- **D-14:** 5+ active beta workspaces installed, each completed at least one poll end-to-end.
+- **D-15:** Zero open P0 or P1 issues from beta feedback.
+- **D-16:** Phase 6 alerting verified in a test (synthetic downtime triggers notification).
+- **D-17:** Landing page, privacy policy, support page live for 7+ days.
+
+**Review contact**
+- **D-18:** Dedicated alias `support@lunchbot.app` used for Slack review correspondence and public support page. Domain registration + forwarding is first task in this phase.
+- **D-19:** Inherits Phase 7 commitment of 2-business-day response SLA.
+
+### Claude's Discretion
+- Exact token format for OAuth state (itsdangerous TimestampSigner vs URLSafeTimedSerializer vs hand-rolled HMAC)
+- Specific Figma template and AI prompts for asset generation
+- Beta feedback collection template / tracker format
+- Domain registrar and forwarding provider for support alias
+- Docstring style for scope justification doc
+
+### Deferred Ideas (OUT OF SCOPE)
+- Public launch channels (IndieHackers, Reddit r/Slack, HN Show, ProductHunt) — post-launch growth phase
+- Adding `chat:write.public` / `im:write` scopes — revisit only if beta feedback demands it, post-approval only
+- In-app feedback widget — email/DM is enough for a 5-workspace beta
+- Paid tier / Stripe billing — deferred per project decision
+- Scheduled post-launch growth experiments
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| MKT-01 | OAuth install flow includes CSRF state parameter | `itsdangerous.URLSafeTimedSerializer` pattern; injection point identified at `oauth.py:39-46` (install) and `oauth.py:49-92` (callback) |
+| MKT-02 | All Slack scopes audited with documented justification | Slack requires least-privilege scope list with written justification [CITED]; current 3 scopes are minimal and defensible |
+| MKT-03 | App icon food/lunch themed, unique, high-res | Slack requires "unique, distinctive, high quality and resolution" [CITED: docs.slack.dev]; 512x512 minimum standard, 1024x1024 recommended per MKT-03 |
+| MKT-04 | App directory screenshots (min 3, 1600x1000, 8:5) | Slack confirms exact spec: "1600px by 1000px size (8:5 ratio)", JPG/JPEG/PNG, under 21MB [CITED: docs.slack.dev] |
+| MKT-05 | YouTube demo video 30-90s with CC | Slack confirms: "between 30-90 seconds", "publicly-accessible YouTube link, not a channel or playlist", "Turn on closed captioning", "turn off ads" [CITED: docs.slack.dev] |
+| MKT-06 | 5+ beta workspaces, each with completed poll | Phase 6 uptime + poll telemetry (from Phase 6 metrics) can verify "completed poll" criterion automatically |
+| MKT-07 | Submission initiated via App Directory dashboard | Submission flow lives in "Manage Distribution → Submit to the Slack App Directory" in app config dashboard [CITED] |
+</phase_requirements>
+
+## Project Constraints (from CLAUDE.md)
+
+- **Python 3.12 + Flask 3.x** (modernized from Flask 1.0 per Phase 1)
+- **Self-hosted Docker on home server** — no cloud, no new infrastructure deps
+- **PostgreSQL** in Docker — state must remain stateless (no new table per D-02)
+- **Slack marketplace compliance** is an explicit top-level project constraint
+- **Freemium model** — free tier functional at launch, billing deferred
+- **GSD workflow** — all edits through planned phases
+- **structlog** is the logging framework (Phase 6) — all new events use it
+- **cryptography.Fernet** already in use for bot token encryption (`oauth.py:27-36`)
+- **Existing pattern:** Config loaded via `current_app.config[...]` at app factory time; env vars fail-fast on missing
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| itsdangerous | 2.2.0 | Sign and timestamp OAuth state tokens | Already a Flask transitive dep (Flask uses it for session cookies); production-hardened by Pallets; `URLSafeTimedSerializer` is the canonical pattern for expiring signed tokens in Flask apps [VERIFIED: itsdangerous.palletsprojects.com] |
+| secrets (stdlib) | — | Generate cryptographic nonces | Python stdlib; `secrets.token_urlsafe(32)` is the documented way to produce OAuth-safe random values [VERIFIED: Python docs] |
+| structlog | existing | Log `oauth_state_invalid` events | Already adopted in Phase 6; all new events must use it per OBS-01 |
+
+**Version verification:**
+```bash
+python3 -c "import itsdangerous; print(itsdangerous.__version__)"
+# Expected: 2.x already present (Flask 3.x transitive dep)
+pip show itsdangerous
+```
+itsdangerous 2.2.0 was released 2024-04-16 and is current as of 2026-04 [CITED: pypi.org/project/itsdangerous]. No install needed — verify it is already pinned in `requirements.txt` or `pyproject.toml`.
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| pytest-freezegun / freezegun | current | Test state expiry without sleeping | In `tests/test_oauth.py` for expired-token test case |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| `URLSafeTimedSerializer` | `TimestampSigner` | Signer is lower-level (raw bytes, no JSON). Serializer handles JSON structure so you can put `{"nonce": "...", "return_to": "..."}` in the token without manual encoding. For a nonce-only token, Signer works — but Serializer is strictly more flexible at zero cost. **Chosen: URLSafeTimedSerializer** |
+| `URLSafeTimedSerializer` | Hand-rolled HMAC (hashlib + hmac) | Hand-rolling is a foot-gun: timing-safe comparison, encoding, timestamp format, constant-time verify all need to be correct. itsdangerous does all of this. No reason to reinvent. |
+| Dedicated `OAUTH_STATE_SECRET` | Reuse `FERNET_KEY` | **Chosen: dedicated secret.** Fernet key is specifically for AES-128-CBC + HMAC token encryption; reusing it for a different cryptographic purpose (HMAC signing of state) violates key-separation principle. Cost of adding one env var is zero; cost of key reuse at an audit is "why does this key sign multiple trust boundaries?". Add `OAUTH_STATE_SECRET` to app factory config loading alongside `FERNET_KEY`. |
+
+**Installation:** No new dependencies needed — itsdangerous is already present as a Flask transitive dep.
+
+## Architecture Patterns
+
+### Recommended Module Layout
+```
+lunchbot/
+├── blueprints/
+│   └── oauth.py              # Existing — add state generation + verification
+├── security/                 # NEW — small helper module
+│   └── oauth_state.py        # make_state_token() / verify_state_token()
+├── config.py                 # Add OAUTH_STATE_SECRET loading
+└── ...
+assets/
+└── marketplace/              # NEW
+    ├── icon-1024.png
+    ├── screenshots/
+    │   ├── 01-install.png    # 1600x1000
+    │   ├── 02-poll.png
+    │   └── 03-vote.png
+    ├── demo-script.md        # Narration script for video
+    └── submission-copy.md    # Short desc, long desc, category
+docs/
+└── slack-scopes.md           # NEW — scope justification (D-05)
+```
+
+### Pattern 1: Stateless Signed State Token
+**What:** Generate a signed, expiring token at `/install`, verify at `/oauth_redirect`.
+**When to use:** Any OAuth CSRF protection where you don't want server-side session storage.
+
+```python
+# lunchbot/security/oauth_state.py
+# Source pattern: itsdangerous.palletsprojects.com/en/stable/
+import secrets
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+
+STATE_SALT = "slack-oauth-state-v1"  # namespace; bump to invalidate all in-flight tokens
+STATE_MAX_AGE_SECONDS = 600           # 10 minutes per D-01
+
+def _serializer(secret: str) -> URLSafeTimedSerializer:
+    return URLSafeTimedSerializer(secret_key=secret, salt=STATE_SALT)
+
+def make_state_token(secret: str) -> str:
+    nonce = secrets.token_urlsafe(32)
+    return _serializer(secret).dumps({"n": nonce})
+
+def verify_state_token(token: str, secret: str) -> bool:
+    """Return True if token is valid and within max_age. False on tamper/expiry/malformed."""
+    if not token:
+        return False
+    try:
+        _serializer(secret).loads(token, max_age=STATE_MAX_AGE_SECONDS)
+        return True
+    except SignatureExpired:
+        return False
+    except BadSignature:
+        return False
+```
+
+**Integration into `oauth.py`:**
+```python
+# install()
+from lunchbot.security.oauth_state import make_state_token, verify_state_token
+
+@bp.route('/install')
+def install():
+    client_id = current_app.config['SLACK_CLIENT_ID']
+    redirect_uri = _redirect_uri()
+    state = make_state_token(current_app.config['OAUTH_STATE_SECRET'])
+    return redirect(
+        f'https://slack.com/oauth/v2/authorize'
+        f'?client_id={client_id}'
+        f'&scope={SCOPES}'
+        f'&redirect_uri={redirect_uri}'
+        f'&state={state}'
+    )
+
+# oauth_redirect() — add verification BEFORE oauth_v2_access call
+@bp.route('/oauth_redirect')
+def oauth_redirect():
+    code = request.args.get('code')
+    state = request.args.get('state')
+    error = request.args.get('error')
+
+    if error or not code:
+        logger.warning('oauth_error', error=error or 'no_code')
+        return _error_page(), 400
+
+    if not verify_state_token(state, current_app.config['OAUTH_STATE_SECRET']):
+        logger.warning('oauth_state_invalid', has_state=bool(state))
+        return _error_page(), 400
+
+    # ... existing token exchange code unchanged ...
+```
+
+### Pattern 2: Scope Justification Doc Format
+**What:** Markdown doc with one paragraph per scope, linking to user-visible feature.
+**When to use:** MKT-02 submission artifact; also used if Slack reviewer asks "why do you need X".
+
+```markdown
+# docs/slack-scopes.md
+# LunchBot Slack Permission Scopes
+
+LunchBot requests the minimum scopes required to run a lunch poll in a channel.
+Each scope below is justified against a user-visible feature.
+
+## `commands`
+**Why:** LunchBot is triggered by the `/lunch` slash command. Without this scope
+the bot cannot be invoked at all. Used in: `lunchbot/blueprints/commands.py`.
+
+## `chat:write`
+**Why:** LunchBot posts the poll message and updates it as votes come in. The
+poll IS the product — without write access the bot produces no output.
+Used in: `lunchbot/service/poll_service.py` (initial post and vote updates).
+
+## `users:read`
+**Why:** LunchBot displays voter names and avatars next to each vote in the
+poll message, so the team can see who has voted. This is a core social
+feature. Only public profile data is read; no email, no custom profile fields.
+Used in: `lunchbot/service/voter.py` for display name + image URL.
+
+## Scopes we deliberately do NOT request
+- `chat:write.public` — we only post to channels the bot was invited to
+- `im:write` — no DMs in v1
+- `channels:read` / `groups:read` — channel selection is via Slack's native picker
+- `users:read.email` — we do not use email for any feature
+```
+
+### Pattern 3: Submission Gate Check Script
+**What:** A script that validates D-13 through D-17 before submission.
+**When to use:** Run immediately before submitting to the App Directory.
+
+```python
+# scripts/submission_gate.py
+# Exits non-zero if any gate fails. Human-readable checklist output.
+# Checks:
+#  1. Uptime monitor: 7 consecutive days green (query Prometheus or Grafana API)
+#  2. Beta workspaces: SELECT COUNT(*) FROM workspaces WHERE deleted_at IS NULL
+#     AND EXISTS (SELECT 1 FROM polls WHERE workspace_id = w.id AND completed_at IS NOT NULL)
+#  3. P0/P1 count: read from beta feedback tracker (CSV/issue tracker)
+#  4. Alert test: last synthetic-downtime alert within 7 days
+#  5. Web page uptime: landing/privacy/support all live 7+ days (HEAD check + git log)
+```
+
+### Anti-Patterns to Avoid
+- **Hand-rolled HMAC state:** Reinventing `hmac` + `hashlib` + base64url + timestamp parsing. Every one of those is a timing-attack or encoding bug waiting to happen. Use itsdangerous.
+- **State in session cookie:** Flask sessions work, but couple install flow to session storage and break if user opens install link in a different browser. Stateless token in URL is explicitly better for OAuth.
+- **Reusing FERNET_KEY for state signing:** Violates key-separation. One compromised secret should not break two trust boundaries.
+- **Adding a `state` column to `workspaces`:** Explicitly forbidden by D-02. Also wrong: state is per-install-attempt, not per-workspace (workspace doesn't exist yet at install time).
+- **Submitting before gate criteria:** Slack review takes up to 10 weeks for new apps. A rejection mid-review resets that clock. The gate exists to prevent preventable rejections.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| OAuth state signing | Custom HMAC + base64 + timestamp parser | `itsdangerous.URLSafeTimedSerializer` | Timing-safe compare, URL-safe encoding, expiry, tamper detection all handled. Pallets maintained. |
+| Random nonce generation | `random.random()` or `uuid.uuid4()` | `secrets.token_urlsafe(32)` | `random` is not cryptographic; `uuid4` is only 122 bits of entropy and not intended for security. `secrets` is the stdlib's CSPRNG interface. |
+| Screenshot 1600x1000 cropping | Manual pixel-fiddling | Figma frame template at 1600x1000 | Single source of truth, exports correct dimensions deterministically |
+| Demo video captions | Hand-timed SRT files | YouTube auto-captions + manual correction pass | Slack just needs CC present; auto-captions + polish meets the bar |
+| Beta recruitment tracker | Custom app | Simple Markdown table in `docs/beta-tracker.md` | 5 workspaces. A spreadsheet is overkill. |
+| Submission gate automation | Elaborate CI pipeline | One Python script run manually before submit | Runs once. Complexity cost > benefit. |
+
+**Key insight:** Phase 8 is a "say yes to boring tools" phase. Every artifact is produced once, reviewed once, and shipped once. Anything custom is technical debt that outlives its purpose the moment Slack approves the listing.
+
+## Common Pitfalls
+
+### Pitfall 1: Rejection for unnecessary scopes
+**What goes wrong:** Reviewer sees a scope with no obvious user-visible justification and rejects.
+**Why it happens:** Developers add scopes "just in case" or copy-paste from tutorials.
+**How to avoid:** LunchBot's three scopes are all clearly feature-linked. The `docs/slack-scopes.md` must ship with the submission — don't wait for the reviewer to ask.
+**Warning signs:** Any PR during this phase that touches `SCOPES = 'commands,chat:write,users:read'` in `oauth.py`. D-06 is a hard lock.
+
+### Pitfall 2: Missing install welcome message
+**What goes wrong:** Slack [CITED: dev.to/tomquirk] explicitly calls out "when a user installs your app, you need to send them a message that explains how to get started" as a common rejection trigger.
+**Why it happens:** Developers focus on the OAuth callback and forget that the moment after install is a first-impression moment.
+**How to avoid:** Verify that after OAuth success, LunchBot posts a welcome message (or App Home tab content) explaining `/lunch`. Phase 5's App Home onboarding covers this — confirm it fires on workspace install, not just on App Home open. Add an install-time smoke test.
+**Warning signs:** Beta testers asking "how do I use this?" after installing.
+
+### Pitfall 3: Privacy policy too generic
+**What goes wrong:** Reviewer rejects a generic privacy-policy template that doesn't name LunchBot's actual data (workspace ID, display names, vote history, encrypted bot token).
+**Why it happens:** Copy-pasting from a generator. WEB-02 acceptance criterion explicitly says "LunchBot-specific, not a generic template" — but double-check during Phase 8.
+**How to avoid:** Read the Phase 7 privacy policy end-to-end, verify it names actual fields from the PostgreSQL schema, and verify it documents the uninstall deletion flow (Phase 2 MTNT-04).
+**Warning signs:** Privacy page doesn't mention "workspace_id", "bot_token", "vote", or "Google Places".
+
+### Pitfall 4: Icon resembles Slack or Slackbot
+**What goes wrong:** AI-generated icons frequently default to speech-bubble or hash shapes that look Slack-adjacent.
+**Why it happens:** "Slack bot icon" prompts drift toward Slack's own branding.
+**How to avoid:** Food-first visual metaphor (sandwich, plate, fork). Verify against https://slack.com/media-kit for brand colors/shapes to avoid. Manual review by user before finalizing.
+**Warning signs:** Purple (#4A154B) or Slack's aubergine in the icon. Speech bubble shape.
+
+### Pitfall 5: Demo video shows non-Slack surfaces
+**What goes wrong:** Video flashes to a web dashboard or code editor, violating "Show your app/service in the context of Slack, not other tools" [CITED: docs.slack.dev].
+**Why it happens:** Natural tendency to show "behind the scenes".
+**How to avoid:** Script the video to stay entirely inside a real Slack workspace. `assets/marketplace/demo-script.md` should enforce this shot list.
+
+### Pitfall 6: State token not URL-encoded in authorize URL
+**What goes wrong:** Tokens from itsdangerous are URL-safe base64, so this usually works — but if you ever introduce a query-string-unsafe character, the redirect breaks silently.
+**How to avoid:** Use `urllib.parse.urlencode({...})` to build the authorize URL instead of f-string concatenation. Current `oauth.py:44-46` uses f-string — fix during MKT-01.
+**Warning signs:** Manual URL construction.
+
+### Pitfall 7: Submission clock resets on rejection
+**What goes wrong:** Rejected submissions go back to the end of the queue. Preliminary review takes up to 10 business days; functional up to 10 weeks [CITED: docs.slack.dev].
+**How to avoid:** The submission gate (D-13–D-17) is not optional hygiene — it is the difference between a 10-week launch and a 20-week launch.
+
+### Pitfall 8: Support contact is personal email
+**What goes wrong:** Slack reviewers expect a professional support contact; a developer gmail signals hobby project and invites scrutiny.
+**How to avoid:** D-18 already mandates `support@lunchbot.app`. Task 1 of this phase is registering the domain and setting up email forwarding. Do this FIRST because DNS propagation and mail-forwarder verification can take 24-48 hours.
+**Warning signs:** Personal email appearing anywhere in submission artifacts or privacy policy.
+
+## Code Examples
+
+### Complete state helper with tests
+```python
+# lunchbot/security/oauth_state.py
+# Source: itsdangerous docs — https://itsdangerous.palletsprojects.com/en/stable/timed/
+import secrets
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+
+STATE_SALT = "slack-oauth-state-v1"
+STATE_MAX_AGE_SECONDS = 600  # 10 min per D-01
+
+def make_state_token(secret: str) -> str:
+    s = URLSafeTimedSerializer(secret_key=secret, salt=STATE_SALT)
+    return s.dumps({"n": secrets.token_urlsafe(32)})
+
+def verify_state_token(token: str | None, secret: str) -> bool:
+    if not token:
+        return False
+    s = URLSafeTimedSerializer(secret_key=secret, salt=STATE_SALT)
+    try:
+        s.loads(token, max_age=STATE_MAX_AGE_SECONDS)
+        return True
+    except (SignatureExpired, BadSignature):
+        return False
+```
+
+```python
+# tests/test_oauth_state.py
+import time
+import pytest
+from freezegun import freeze_time
+from lunchbot.security.oauth_state import make_state_token, verify_state_token
+
+SECRET = "test-secret-do-not-use-in-prod"
+
+def test_valid_token_roundtrip():
+    token = make_state_token(SECRET)
+    assert verify_state_token(token, SECRET) is True
+
+def test_tampered_signature_rejected():
+    token = make_state_token(SECRET)
+    tampered = token[:-4] + "XXXX"
+    assert verify_state_token(tampered, SECRET) is False
+
+def test_wrong_secret_rejected():
+    token = make_state_token(SECRET)
+    assert verify_state_token(token, "different-secret") is False
+
+def test_expired_token_rejected():
+    with freeze_time("2026-01-01 12:00:00") as frozen:
+        token = make_state_token(SECRET)
+        frozen.tick(delta=601)  # 601 seconds = past 10-minute expiry
+        assert verify_state_token(token, SECRET) is False
+
+def test_empty_token_rejected():
+    assert verify_state_token("", SECRET) is False
+    assert verify_state_token(None, SECRET) is False
+
+def test_malformed_token_rejected():
+    assert verify_state_token("not-a-token", SECRET) is False
+```
+
+### Config loading addition
+```python
+# lunchbot/config.py (existing file — add one entry)
+OAUTH_STATE_SECRET = os.environ['OAUTH_STATE_SECRET']  # fail-fast per existing pattern
+```
+
+### URL building with urlencode
+```python
+# oauth.py install() — safer URL construction
+from urllib.parse import urlencode
+
+@bp.route('/install')
+def install():
+    params = {
+        'client_id': current_app.config['SLACK_CLIENT_ID'],
+        'scope': SCOPES,
+        'redirect_uri': _redirect_uri(),
+        'state': make_state_token(current_app.config['OAUTH_STATE_SECRET']),
+    }
+    return redirect(f'https://slack.com/oauth/v2/authorize?{urlencode(params)}')
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| State in Flask session | Stateless signed token | Always (for OAuth) | Works across browser windows, no session coupling |
+| `random.random()` for nonces | `secrets.token_urlsafe()` | Python 3.6+ | Cryptographically secure; stdlib approved |
+| Hand-rolled HMAC | `itsdangerous.URLSafeTimedSerializer` | Flask ecosystem convention | Timing-safe; fewer bugs |
+| `api.slack.com/slack-marketplace/guidelines` (legacy URL) | `docs.slack.dev/slack-marketplace/slack-marketplace-app-guidelines-and-requirements/` | ~2025 Slack docs migration | Old URLs 302-redirect; update any bookmarks |
+
+**Deprecated/outdated:**
+- `api.slack.com/legacy/oauth` — legacy OAuth 1.0 flow, not applicable to LunchBot (already on OAuth V2).
+- Scopes `read`, `post`, `client`, `search:read` — legacy/banned scopes. Not requested by LunchBot [CITED: docs.slack.dev review guide].
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | itsdangerous 2.x is already in the dependency tree as a Flask transitive | Standard Stack | Low — `pip show itsdangerous` during Task 1 will confirm; if missing, add one line to requirements |
+| A2 | `secrets.token_urlsafe(32)` provides sufficient entropy for the nonce | Code Examples | None — this is the stdlib's documented CSPRNG output, 256 bits of entropy |
+| A3 | Icon 1024x1024 requirement comes from MKT-03, not from Slack docs directly | Phase Requirements | Slack doesn't publish an exact icon pixel spec in current docs [CITED]. 1024x1024 is an industry-standard upper bound that is guaranteed to pass. No risk. |
+| A4 | Minimum 3 screenshots comes from MKT-03/MKT-04, not Slack docs | Phase Requirements | Slack docs do not specify a minimum count [CITED: docs.slack.dev]. 3 is a practical floor — user decision in requirements stands. |
+| A5 | Review timelines (10d preliminary, 10wk functional) reflect 2025/2026 reality | Summary | MEDIUM — timelines published by Slack as upper bounds; real wait times reported in community vary from 2wk to 10wk. Plan for the upper bound. |
+| A6 | Current 3 scopes (`commands`, `chat:write`, `users:read`) are actually used by code | Phase Requirements | Verifiable via grep; planner should include a "scope usage audit" task that greps for each scope's API calls to confirm `docs/slack-scopes.md` is truthful |
+| A7 | Phase 5 App Home onboarding fires on workspace install (not only on App Home open) | Pitfall 2 | MEDIUM — needs verification. If Phase 5 only handles `app_home_opened` event, an explicit post-install welcome message task is required in Phase 8 to avoid rejection. Planner should inspect Phase 5 code. |
+| A8 | Domain `lunchbot.app` is available for registration | D-18 support alias | HIGH — if taken, need an alternative domain. Resolve in Task 1 of the phase. |
+
+## Open Questions
+
+1. **Is itsdangerous pinned in the project's dependency lockfile?**
+   - What we know: Flask 3.x depends on itsdangerous ≥2.1.2.
+   - What's unclear: Whether it's an explicit dep or relying on transitive resolution.
+   - Recommendation: Planner adds a task to pin `itsdangerous>=2.2.0` explicitly in `requirements.txt` — never rely on transitive pins for security-critical code.
+
+2. **Does Phase 5's App Home handler cover the install event?**
+   - What we know: Phase 5 implements App Home onboarding (BOT-10).
+   - What's unclear: Whether the welcome message fires on OAuth-complete or only on `app_home_opened`.
+   - Recommendation: Planner reads Phase 5's `05-03-PLAN.md` + implementation and either confirms coverage or adds a Phase 8 task to post a welcome message directly after the OAuth success redirect.
+
+3. **Is `lunchbot.app` registered?**
+   - Recommendation: Task 1 of the phase is domain registration. If unavailable, alternatives: `lunchbot.fyi`, `getlunchbot.com`, `lunchbot.team`. Blocks D-18.
+
+4. **Exact icon pixel spec from Slack — is 1024x1024 actually required or is this user preference?**
+   - Slack's current docs [CITED] do not publish an exact pixel count, only "high quality and resolution". MKT-03 says 1024x1024 — treat that as an internal spec, not a Slack mandate. No risk of rejection for going higher; 512x512 would probably also pass but 1024 is safer.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| itsdangerous | MKT-01 state signing | ✓ (transitive via Flask 3.x) | 2.x | Pin explicitly in requirements |
+| Python `secrets` module | Nonce generation | ✓ | stdlib | — |
+| freezegun | Test expired-token case | Unknown | — | `time.sleep(601)` in test (slow but works) |
+| Figma | Icon + screenshot production (D-07) | User-controlled | — | Any vector tool; final export to PNG |
+| YouTube account | Demo video hosting (MKT-05) | User-controlled | — | No alternative — Slack requires YouTube per [CITED: docs.slack.dev] |
+| Domain registrar | `lunchbot.app` registration (D-18) | User-controlled | — | Alternative TLDs if `.app` taken |
+| Email forwarding | `support@lunchbot.app` alias | Needs setup | — | Fastmail, Cloudflare Email Routing (free), ImprovMX (free) |
+
+**Missing dependencies with no fallback:**
+- YouTube hosting is hard-required by Slack. No alternative video hosts accepted.
+
+**Missing dependencies with fallback:**
+- freezegun: add to `requirements-dev.txt`; trivial install
+- Email forwarding: Cloudflare Email Routing is free and fast to set up if Cloudflare holds the DNS
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | pytest (existing Phase 1-7 test harness) |
+| Config file | `pyproject.toml` / `pytest.ini` (confirm during Wave 0) |
+| Quick run command | `pytest tests/test_oauth_state.py tests/test_oauth.py -x` |
+| Full suite command | `pytest` |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| MKT-01 | `make_state_token` produces valid token | unit | `pytest tests/test_oauth_state.py::test_valid_token_roundtrip -x` | ❌ Wave 0 |
+| MKT-01 | Tampered signature rejected | unit | `pytest tests/test_oauth_state.py::test_tampered_signature_rejected -x` | ❌ Wave 0 |
+| MKT-01 | Wrong secret rejected | unit | `pytest tests/test_oauth_state.py::test_wrong_secret_rejected -x` | ❌ Wave 0 |
+| MKT-01 | Expired token rejected (>10 min) | unit (freezegun) | `pytest tests/test_oauth_state.py::test_expired_token_rejected -x` | ❌ Wave 0 |
+| MKT-01 | Empty/None token rejected | unit | `pytest tests/test_oauth_state.py::test_empty_token_rejected -x` | ❌ Wave 0 |
+| MKT-01 | `/install` includes `state` in redirect URL | integration | `pytest tests/test_oauth.py::test_install_includes_state -x` | ⚠️ extend existing |
+| MKT-01 | `/oauth_redirect` rejects missing/invalid state with error page + structlog event | integration | `pytest tests/test_oauth.py::test_callback_rejects_invalid_state -x` | ⚠️ extend existing |
+| MKT-01 | `/oauth_redirect` accepts valid state and proceeds to token exchange | integration | `pytest tests/test_oauth.py::test_callback_accepts_valid_state -x` | ⚠️ extend existing |
+| MKT-02 | `docs/slack-scopes.md` exists and lists all 3 scopes | doc lint | `pytest tests/test_docs.py::test_scopes_doc_complete -x` | ❌ Wave 0 |
+| MKT-02 | Scope list in code matches scope doc | lint | `pytest tests/test_docs.py::test_scopes_doc_matches_code -x` | ❌ Wave 0 |
+| MKT-03 | Icon file exists at `assets/marketplace/icon-1024.png` and is 1024x1024 | manual + asset check | `pytest tests/test_assets.py::test_icon_dimensions -x` (using Pillow) | ❌ Wave 0 |
+| MKT-04 | 3+ screenshots exist, each 1600x1000 | asset check | `pytest tests/test_assets.py::test_screenshot_dimensions -x` | ❌ Wave 0 |
+| MKT-05 | Demo video URL present in `assets/marketplace/submission-copy.md`, 30-90s, CC present | manual | documented in `assets/marketplace/demo-checklist.md` | ❌ Wave 0 |
+| MKT-06 | 5+ workspaces with ≥1 completed poll | live data check | `python scripts/submission_gate.py --check beta` | ❌ Wave 0 |
+| MKT-07 | All gate criteria pass | live data check | `python scripts/submission_gate.py` | ❌ Wave 0 |
+
+### Sampling Rate
+- **Per task commit:** `pytest tests/test_oauth_state.py tests/test_oauth.py -x` (≈1 second)
+- **Per wave merge:** `pytest` (full suite)
+- **Phase gate:** Full suite green + `python scripts/submission_gate.py` all-green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+- [ ] `tests/test_oauth_state.py` — unit tests for `make_state_token` / `verify_state_token`
+- [ ] `tests/test_docs.py` — doc-lint tests for scope justification sync with code
+- [ ] `tests/test_assets.py` — Pillow-based asset dimension checks
+- [ ] `scripts/submission_gate.py` — automated gate checker (D-13–D-17)
+- [ ] `assets/marketplace/` directory scaffold
+- [ ] `docs/slack-scopes.md` scaffold
+- [ ] Framework addition: `freezegun` and `Pillow` in `requirements-dev.txt`
+- [ ] Existing `tests/test_oauth.py` extension: state happy-path, state rejection, existing callback tests must still pass with new state requirement
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | yes | Slack OAuth V2 (existing); state parameter adds CSRF protection |
+| V3 Session Management | no | No user sessions — stateless bot |
+| V4 Access Control | yes | PostgreSQL RLS already enforced per workspace (Phase 2) — unchanged |
+| V5 Input Validation | yes | Verify `code`, `state`, `error` query params at callback boundary — existing `_error_page` on bad inputs |
+| V6 Cryptography | yes | `itsdangerous` for state HMAC signing; `cryptography.Fernet` for bot token encryption (existing). Never hand-roll. |
+| V14 Configuration | yes | `OAUTH_STATE_SECRET` separate from `FERNET_KEY` — key separation principle |
+
+### Known Threat Patterns for Slack OAuth
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| CSRF on install flow (attacker tricks victim into installing attacker-chosen workspace) | Tampering | Signed `state` parameter with nonce + expiry (this phase) |
+| State token replay | Tampering | Short TTL (10 min) + nonce in payload. True one-time enforcement would require server-side storage — gap accepted per D-02 (stateless). 10-minute window is standard. |
+| Signature forgery | Tampering | HMAC via itsdangerous timing-safe compare |
+| Stolen FERNET_KEY from code reuse | Information Disclosure | Separate `OAUTH_STATE_SECRET` — compromise of one doesn't break the other |
+| Bot token in logs | Information Disclosure | Never log `response['access_token']`; existing code doesn't — verify structlog redaction policy is in place |
+| Open redirect via `redirect_uri` manipulation | Tampering | Slack's own redirect_uri allowlist enforces this at Slack's end |
+
+**Replay note (A2 risk):** D-01 says "rejects expired OR reused tokens". True replay detection (reuse within the 10-minute window) requires stateful tracking. itsdangerous timestamped tokens do NOT detect replay — only expiry + tampering. The 10-minute window is the accepted tradeoff per D-02 (stateless). If the planner interprets D-01 strictly, they must either (a) accept the stateless tradeoff (recommended) or (b) surface this to the user as a second discuss-phase question. **Recommendation: accept stateless. The realistic attack — replay within 10 minutes — is already extremely constrained, and Slack's own docs and SDK defaults use the same stateless pattern.**
+
+## Sources
+
+### Primary (HIGH confidence)
+- https://docs.slack.dev/slack-marketplace/slack-marketplace-app-guidelines-and-requirements/ — Icon, screenshot (1600x1000, 8:5), video (30-90s, YouTube, CC, no ads), descriptions, privacy policy, support page requirements, OAuth state requirement
+- https://docs.slack.dev/slack-marketplace/slack-marketplace-review-guide/ — Preliminary review (up to 10 business days), functional review (up to 10 weeks new / 6 weeks updates), banned scopes list
+- https://api.slack.com/reference/slack-apps/directory-submission-checklist — Interactive submission checklist (must be accessed via app dashboard during submission)
+- https://itsdangerous.palletsprojects.com/en/stable/ — URLSafeTimedSerializer API, timestamped signing semantics, max_age verification
+- https://docs.python.org/3/library/secrets.html — `secrets.token_urlsafe()` CSPRNG
+
+### Secondary (MEDIUM confidence)
+- https://dev.to/tomquirk/5-reasons-why-slack-will-reject-your-slack-app-39m8 — Common rejection patterns (verified against Slack's own review guide; matches)
+- https://github.com/slackapi/node-slack-sdk/issues/1435 — State parameter best practices discussion thread
+- https://medium.com/slack-developer-blog/the-slack-app-directory-checklist-e3f3ba0ca7c5 — Slack Developer Blog checklist (official author but older; cross-verified with current docs.slack.dev)
+
+### Tertiary (LOW confidence)
+- Community timeline reports (review takes 2-10 weeks variance) — directionally useful for planning, treat Slack's official upper bound (10 weeks) as the planning number
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack (itsdangerous, secrets): HIGH — Pallets-maintained, stdlib, widely deployed
+- OAuth state pattern: HIGH — canonical Flask ecosystem pattern with clear docs
+- Slack submission requirements: HIGH for specs in docs.slack.dev; MEDIUM for review timeline (Slack publishes upper bounds, actual varies)
+- Rejection reasons: MEDIUM — community-sourced patterns cross-verified against official review guide
+- Phase 5 App Home install-event coverage: UNKNOWN — flagged as Open Question 2, requires planner verification
+
+**Research date:** 2026-04-15
+**Valid until:** 2026-05-15 (30 days — Slack docs are stable; re-verify review timeline and guidelines URL before submission)

--- a/.planning/phases/08-marketplace-submission/08-VALIDATION.md
+++ b/.planning/phases/08-marketplace-submission/08-VALIDATION.md
@@ -1,0 +1,74 @@
+---
+phase: 8
+slug: marketplace-submission
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-04-15
+---
+
+# Phase 8 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest 8.x |
+| **Config file** | pyproject.toml (existing) |
+| **Quick run command** | `pytest tests/test_oauth.py tests/test_oauth_state.py -q` |
+| **Full suite command** | `pytest -q` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run quick command above
+- **After every plan wave:** Run full suite
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+To be filled by gsd-planner. Phase spans code (MKT-01 OAuth state), docs (MKT-02 scope justification), asset production (MKT-03/04/05), process (MKT-06/07). Automated tests cover MKT-01 and MKT-02; other requirements are manual-only or scripted gates.
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/test_oauth_state.py` — new test file for HMAC state token helper (happy path, tampered, expired, replay-within-window)
+- [ ] `tests/test_oauth.py` — extend existing tests for install→callback state round-trip
+- [ ] `tests/test_scopes_doc.py` — lint `docs/slack-scopes.md` against `SCOPES` constant in oauth.py
+- [ ] Pin `itsdangerous` explicitly in requirements.txt if not already pinned
+- [ ] Add `freezegun` to dev deps if not present (for expired-state test)
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| App icon design approval | MKT-03 | Subjective visual quality | Icon file exists at `assets/marketplace/icon.png`, 1024x1024, reviewed by user |
+| Screenshot quality | MKT-04 | Visual | 3+ PNG files at `assets/marketplace/screenshot-*.png`, 1600x1000, 8:5 |
+| Demo video | MKT-05 | Recording + upload | YouTube public link with CC on, 30-90s, shot in real Slack workspace |
+| Beta workspace count | MKT-06 | External — depends on users | `scripts/submission_gate.py` reports 5+ workspaces with ≥1 completed poll |
+| Submission form filled | MKT-07 | External Slack portal | Screenshot of submission confirmation |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/260415-p4t-PLAN.md
+++ b/.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/260415-p4t-PLAN.md
@@ -1,0 +1,277 @@
+---
+phase: quick-260415-p4t
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - migrations/versions/007_workspace_locations_and_channel_bindings.py
+  - lunchbot/client/workspace_client.py
+  - lunchbot/blueprints/oauth.py
+  - lunchbot/blueprints/polls.py
+  - lunchbot/blueprints/slack_actions.py
+  - lunchbot/services/poll_service.py
+  - tests/test_channel_location_binding.py
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "OAuth install URL requests chat:write.public in addition to existing scopes"
+    - "A workspace can have multiple named locations (office_id, name, lat_lng)"
+    - "A channel has at most one location_id bound to it; binding persists"
+    - "/lunch in an unbound channel prompts the user to pick a location before posting a poll (if workspace has >1 location OR a default exists to choose from)"
+    - "/lunch in an unbound channel with exactly one workspace location auto-binds silently and posts the poll"
+    - "/lunch in an already-bound channel posts the poll immediately and does NOT re-prompt"
+    - "poll_service, emoji_service seed, and any place-search path resolve location via the channel binding (not workspace.location)"
+  artifacts:
+    - path: "migrations/versions/007_workspace_locations_and_channel_bindings.py"
+      provides: "workspace_locations + channel_locations tables, backfill from workspaces.location"
+      contains: "CREATE TABLE workspace_locations"
+    - path: "lunchbot/client/workspace_client.py"
+      provides: "list_workspace_locations, create_workspace_location, get_channel_location, bind_channel_location, resolve_location_for_channel"
+    - path: "lunchbot/blueprints/oauth.py"
+      provides: "SCOPES includes chat:write.public"
+      pattern: "chat:write\\.public"
+    - path: "lunchbot/blueprints/polls.py"
+      provides: "slash_command routes through channel-location resolver"
+    - path: "lunchbot/blueprints/slack_actions.py"
+      provides: "handlers for channel_location_bind action ids"
+    - path: "tests/test_channel_location_binding.py"
+      provides: "tests for migration shape + resolver logic + scope string"
+  key_links:
+    - from: "lunchbot/blueprints/polls.py::slash_command"
+      to: "workspace_client.resolve_location_for_channel"
+      via: "called before poll_service.push_poll; if returns None, posts ephemeral prompt instead"
+    - from: "lunchbot/blueprints/slack_actions.py"
+      to: "workspace_client.bind_channel_location"
+      via: "action handler persists user's choice, then triggers poll_service.push_poll"
+    - from: "lunchbot/services/poll_service.py (and emoji seed path)"
+      to: "workspace_client.resolve_location_for_channel(team_id, channel)"
+      via: "replaces reads of workspace['location']"
+---
+
+<objective>
+Add the Slack `chat:write.public` scope and introduce per-channel office location bindings so a single install can serve multiple offices, with exactly one location locked per channel and a first-use prompt when an unbound channel invokes `/lunch`.
+
+Purpose: Required for marketplace submission (post without being invited) and for teams with multiple offices sharing one install. Preserves the existing single-location-per-workspace model as a compatible fallback during migration.
+
+Output: Scope change live in install URL, new location data model with channel bindings, first-use prompt flow, all code paths reading from the new resolver.
+</objective>
+
+<execution_context>
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/daniel.torbacka/dev/private/Lunch/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@.planning/PROJECT.md
+@.planning/STATE.md
+
+@lunchbot/blueprints/oauth.py
+@lunchbot/blueprints/polls.py
+@lunchbot/blueprints/slack_actions.py
+@lunchbot/client/workspace_client.py
+@lunchbot/services/poll_service.py
+@migrations/versions/004_workspace_location.py
+@migrations/versions/006_poll_option_metadata.py
+
+<interfaces>
+<!-- Current state of key integration points. -->
+
+Current OAuth scopes (lunchbot/blueprints/oauth.py:18):
+```python
+SCOPES = 'commands,chat:write,users:read'
+```
+
+Current location storage (workspaces table, migration 004):
+```sql
+ALTER TABLE workspaces ADD COLUMN location VARCHAR(64)  -- "lat,lng" string
+```
+
+Current entry point (lunchbot/blueprints/polls.py:24-57):
+```python
+@bp.route('/slack/command', methods=['POST'])
+def slash_command():
+    team_id = request.form.get('team_id', '')
+    channel = request.form.get('channel_id', '')
+    text = request.form.get('text', '').strip().lower()
+    # ...routes to poll_service.push_poll(channel, team_id)
+```
+
+Current location reads (grep confirmed, 2 sites):
+- lunchbot/blueprints/polls.py:96   — seed endpoint
+- lunchbot/blueprints/slack_actions.py:292 — some action handler
+
+Both do: `location = workspace.get('location') if workspace else None`
+
+Slack action dispatch pattern (slack_actions.py): actions are routed by `action_id`
+extracted from `first_action.get('action_id', '')`, with handlers keyed on action_id
+constants at module top.
+
+`workspace_client.get_workspace_settings` returns `location` in its SELECT — callers
+that only need the effective location for a channel should go through the new resolver.
+</interfaces>
+</context>
+
+<note_on_scope>
+This is a coupled quick task. Three tasks is tight but achievable because:
+- Task 1 = pure data layer (migration + client functions + backfill), no Slack surface
+- Task 2 = OAuth scope change + slash-command resolver + prompt dispatch (thin glue)
+- Task 3 = action handler persistence + migration of two existing read sites + tests
+
+If the executor finds that the interactive prompt UX requires more than a trivial Block
+Kit message (e.g., modal with Place autocomplete to CREATE a new office), STOP and
+escalate to `/gsd-plan-phase`. The plan assumes the first-time prompt is an ephemeral
+message with buttons: "Use default office ({name})" and "Pick another office", where
+"Pick another" opens a static_select populated from existing workspace_locations rows
+(creation of NEW offices stays in App Home / existing settings flow — out of scope).
+</note_on_scope>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Data model — workspace_locations + channel_locations with backfill</name>
+  <files>migrations/versions/007_workspace_locations_and_channel_bindings.py, lunchbot/client/workspace_client.py, tests/test_channel_location_binding.py</files>
+  <behavior>
+    - Migration 007 upgrade creates two tables:
+        workspace_locations(id uuid/serial PK, team_id text NOT NULL references workspaces(team_id) on delete cascade, name text NOT NULL, lat_lng varchar(64) NOT NULL, is_default boolean default false, created_at timestamptz default now(), unique(team_id, name))
+        channel_locations(channel_id text NOT NULL, team_id text NOT NULL, location_id references workspace_locations(id) on delete cascade, created_at timestamptz default now(), PRIMARY KEY (team_id, channel_id))
+    - RLS policy added on both tables matching existing tenant-isolation pattern from migration 002 (lookup policy names in that file; team_id = current_setting('app.current_team_id', true))
+    - Backfill: for every workspace row with a non-null location, INSERT one workspace_locations row (name='Default', lat_lng=location, is_default=true)
+    - workspaces.location column is NOT dropped (kept for rollback safety; note in docstring that it is deprecated and no longer read after this plan lands)
+    - Downgrade drops channel_locations then workspace_locations
+    - New client functions in workspace_client.py (snake_case, no type hints, minimal docstrings per CLAUDE.md):
+        list_workspace_locations(team_id) -> list of dict rows
+        create_workspace_location(team_id, name, lat_lng, is_default=False) -> dict
+        get_default_location(team_id) -> dict or None
+        get_channel_location(team_id, channel_id) -> dict (joined workspace_locations row) or None
+        bind_channel_location(team_id, channel_id, location_id) -> None  (upsert via ON CONFLICT (team_id, channel_id))
+        resolve_location_for_channel(team_id, channel_id) -> dict or None
+          Resolver semantics (this is the load-bearing contract used by Task 2+3):
+            1. If channel binding exists → return its joined location row
+            2. Else if workspace has exactly one workspace_locations row → auto-bind it to this channel and return it
+            3. Else → return None (caller must prompt)
+    - Test file covers: migration up/down round-trip on a test DB (follow existing tests/ pattern — check tests/ dir for an existing migration test as reference), backfill creates one default per workspace with a non-null legacy location, resolver returns None when workspace has multiple locations and no binding, resolver auto-binds when workspace has exactly one, resolver respects existing binding.
+  </behavior>
+  <action>
+    Read tests/ directory first to find the existing migration test pattern and psycopg fixture. Then:
+    1. Read migrations/versions/002_multi_tenancy.py to copy the EXACT RLS policy DDL pattern (policy name format, USING clause) — do not invent a new pattern.
+    2. Create migration 007 with both tables, indexes on (team_id) for workspace_locations, RLS enabled + policies, and the backfill INSERT ... SELECT from workspaces WHERE location IS NOT NULL.
+    3. Add the six client functions to workspace_client.py below the existing ones, following the `with get_pool().connection() as conn:` + `dict_row` pattern already used in the file. Use psycopg named params (`%(team_id)s`) exclusively. Do NOT add type hints.
+    4. The resolver's auto-bind branch must be atomic: SELECT count/single row + INSERT inside the same connection. Log via module logger.
+    5. Write tests in tests/test_channel_location_binding.py using whatever fixture tests/ already has. Include a test that asserts `SCOPES` constant is a string containing 'chat:write.public' — this is a forward reference to Task 2 that will fail until Task 2 lands (RED for Task 2's scope change). Mark with a comment `# Task 2 precondition`.
+  </action>
+  <verify>
+    <automated>cd /Users/daniel.torbacka/dev/private/Lunch && .venv/bin/pytest tests/test_channel_location_binding.py -x -q 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    Migration 007 applies cleanly (up + down), new client functions exist and are importable, resolver behaves per the three-branch contract, tests pass except the scope-precondition test which may be xfail until Task 2.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Scope change + slash-command resolver + first-use prompt</name>
+  <files>lunchbot/blueprints/oauth.py, lunchbot/blueprints/polls.py, lunchbot/services/poll_service.py, tests/test_channel_location_binding.py</files>
+  <behavior>
+    - oauth.SCOPES string contains 'chat:write.public' (added to existing comma-separated list, order does not matter).
+    - slash_command in polls.py calls resolve_location_for_channel(team_id, channel) before push_poll.
+        - If resolver returns a row → store nothing extra, proceed to push_poll as today.
+        - If resolver returns None → return ephemeral message (response_type=ephemeral) with two interactive blocks:
+            * Button "use_default_location" (only shown if get_default_location(team_id) returns a row) with value = default location_id, text "Use default office: {name}"
+            * Overflow OR static_select "pick_channel_location" populated from list_workspace_locations(team_id), value = location_id
+          action_ids: CHANNEL_LOC_USE_DEFAULT = 'channel_loc_use_default', CHANNEL_LOC_PICK = 'channel_loc_pick'
+          Define these constants at the top of polls.py (or a new lunchbot/constants.py if one already exists — check first).
+        - The ephemeral payload must include the original channel_id in button `value` (or block metadata) so the action handler in Task 3 can re-issue push_poll in the correct channel.
+    - push_poll signature unchanged; it is still called with (channel, team_id). The resolver is an OUTER gate, not a parameter to push_poll (avoids refactoring poll_service internals in a quick task).
+    - Tests added to tests/test_channel_location_binding.py:
+        * test_scopes_include_chat_write_public: imports SCOPES and asserts 'chat:write.public' in it (flip the xfail from Task 1)
+        * test_slash_command_unbound_multi_location_prompts: mocks resolver to return None + list_workspace_locations to return 2 rows + get_default_location to return one; asserts POST /slack/command body contains the two action_ids and response_type=ephemeral
+        * test_slash_command_bound_posts_directly: mocks resolver to return a row; asserts poll_service.push_poll was called once with (channel, team_id)
+        * test_slash_command_single_location_auto_binds: mocks resolver to return a row (auto-bind already happened in Task 1 resolver); asserts push_poll called
+  </behavior>
+  <action>
+    1. Edit oauth.py line 18: `SCOPES = 'commands,chat:write,chat:write.public,users:read'`. Do not touch anything else in oauth.py.
+    2. Edit polls.py slash_command: keep help/close branches unchanged. For the default (push poll) branch, insert resolver gate. Build the ephemeral prompt as a small helper `_build_channel_location_prompt(team_id, channel)` returning the full jsonify payload. Use Block Kit actions block with button elements. Do NOT open a modal — ephemeral message is sufficient per the <note_on_scope>.
+    3. Make sure the /lunch_message scheduler endpoint ALSO goes through the resolver; if it returns None, log a warning and return 400 with 'channel not bound to a location' (scheduler can't prompt a human, so it must fail loudly). Do not block on this if the scheduler path is already unused for unbound channels in practice — check STATE.md for scheduler usage.
+    4. Add the three new tests to tests/test_channel_location_binding.py using pytest monkeypatch for resolver. Use Flask test client (`app.test_client()`) — tests/ directory already has this pattern, reuse it.
+    5. Flip the Task 1 precondition test from xfail to normal pass.
+    6. Log an info line when prompt is sent: `logger.info('channel_location_prompt', team_id=..., channel=...)` if structlog is used in polls.py (check existing style — polls.py currently uses stdlib logging; match it).
+  </action>
+  <verify>
+    <automated>cd /Users/daniel.torbacka/dev/private/Lunch && .venv/bin/pytest tests/test_channel_location_binding.py -x -q 2>&1 | tail -40</automated>
+  </verify>
+  <done>
+    Scope string contains chat:write.public, unbound channel gets an ephemeral prompt with two action buttons, bound channel posts immediately, single-location workspace never sees the prompt (auto-bind in resolver), scheduler endpoint fails clearly on unbound channels, all tests green.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Action handler persists binding + migrate existing location reads</name>
+  <files>lunchbot/blueprints/slack_actions.py, lunchbot/blueprints/polls.py, lunchbot/services/poll_service.py, tests/test_channel_location_binding.py</files>
+  <behavior>
+    - slack_actions.py dispatches two new action_ids: CHANNEL_LOC_USE_DEFAULT and CHANNEL_LOC_PICK (import constants from polls.py or shared constants module — match what Task 2 chose).
+    - On either action:
+        1. Extract team_id, channel_id, and location_id (from button value for USE_DEFAULT; from selected_option.value for PICK)
+        2. Call workspace_client.bind_channel_location(team_id, channel_id, location_id)
+        3. Call poll_service.push_poll(channel_id, team_id, trigger_source='channel_bind')
+        4. Return 200 empty
+    - Existing location read sites migrated to the new resolver:
+        * lunchbot/blueprints/polls.py:96 (seed endpoint) — now requires channel query param and uses resolve_location_for_channel(team_id, channel). If None → 400 'no location bound for channel'. Keep legacy behavior if channel not provided? NO — require channel, simpler. Seed is an admin trigger; breaking signature is acceptable for a pre-launch quick task.
+        * lunchbot/blueprints/slack_actions.py:292 — same treatment. Read what that handler does first (probably emoji refresh); pass the channel from the action payload to the resolver.
+    - Any call site that reads workspace['location'] or workspace.get('location') directly must be replaced with resolve_location_for_channel. Grep confirms only the two sites above exist; re-run grep to be sure.
+    - workspace_client.get_workspace_settings: leave the `location` column in the SELECT (it still exists in the schema for rollback), but add a docstring line that it is deprecated — DO NOT have any new code depend on it.
+    - Tests added:
+        * test_channel_loc_use_default_action: posts a fake Slack interactive payload, asserts bind_channel_location was called with correct args and push_poll was called
+        * test_channel_loc_pick_action: same for the static_select variant
+        * test_no_remaining_direct_workspace_location_reads: greps lunchbot/ for `workspace\['location'\]` and `workspace.get\('location'\)` and asserts count is 0 (except inside workspace_client.py itself and the deprecated settings SELECT). Can be implemented with subprocess or Path.rglob+re.
+  </behavior>
+  <action>
+    1. Re-run grep to confirm the read sites list has not drifted: `grep -rn "workspace\['location'\]\|workspace.get('location')" lunchbot/`.
+    2. Open slack_actions.py around line 292 to understand what that handler needs the location FOR — it likely triggers a re-seed or place search. Wire it to the channel from the action payload (`payload['channel']['id']`).
+    3. Add the two new action_id branches to slack_actions.py following the existing `if action_id == ...` dispatch pattern. Import bind_channel_location and push_poll. Do NOT refactor the existing dispatch structure.
+    4. Edit polls.py `seed` endpoint: accept channel query arg in addition to team_id; use resolver; return 400 on None with a clear message.
+    5. Add the three tests. The `test_no_remaining_direct_workspace_location_reads` test is a safety net — use pathlib + re, skip workspace_client.py and any file under tests/.
+    6. Run the FULL project test suite at the end to catch regressions in existing tests (poll_service, slack_actions, oauth tests).
+  </action>
+  <verify>
+    <automated>cd /Users/daniel.torbacka/dev/private/Lunch && .venv/bin/pytest -x -q 2>&1 | tail -40</automated>
+  </verify>
+  <done>
+    Both action handlers persist the binding and trigger the poll, zero remaining direct reads of workspace.location anywhere outside workspace_client.py, full project test suite green, manual smoke path documented in the SUMMARY: install → /lunch in unbound channel → pick office → poll appears → /lunch again in same channel → no prompt, poll posts directly.
+  </done>
+</task>
+
+</tasks>
+
+<out_of_scope_notes>
+Explicitly NOT in this plan (document in SUMMARY):
+- Admin UX for editing/removing channel bindings (App Home panel). A channel binding, once set, can only be changed via DB for now.
+- Backfill of existing multi-location installs — there are none; all current workspaces are single-location, handled by Task 1's backfill.
+- Creating NEW office locations from the prompt itself. New locations must still be added via the existing location settings flow (App Home). The prompt only lets users PICK an existing one or use the default.
+- Dropping the legacy workspaces.location column. Kept for rollback; slated for a future cleanup quick task once this has baked.
+- Slack App Manifest file update — if a manifest.yml/json exists, it is NOT touched here (grep did not surface one at root). If the executor finds one during Task 2, add chat:write.public there too and note it in the SUMMARY.
+</out_of_scope_notes>
+
+<verification>
+Full suite: `pytest -x -q`
+Manual smoke (post-execution, documented in SUMMARY):
+1. Install flow: visit /slack/install, verify redirect URL query string contains `chat:write.public`
+2. In a channel where the bot is NOT a member and no binding exists, run /lunch → ephemeral prompt appears
+3. Click "Use default office" → poll posts in same channel (bot was not invited)
+4. Run /lunch again → poll posts immediately, no prompt
+5. In a different channel, run /lunch → prompt appears again (binding is per-channel)
+</verification>
+
+<success_criteria>
+- `chat:write.public` present in OAuth install URL
+- New tables `workspace_locations` and `channel_locations` exist with RLS matching migration 002 pattern
+- Resolver contract holds: bound → return, single-location → auto-bind, else → None
+- /lunch in unbound channel shows ephemeral prompt; /lunch in bound channel posts directly
+- Zero direct reads of `workspace['location']` outside workspace_client.py
+- Full pytest suite green
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/260415-p4t-SUMMARY.md` documenting: scope added, migration number, new client functions, prompt UX chosen, any manifest file found, and the manual smoke test results.
+</output>

--- a/.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/260415-p4t-SUMMARY.md
+++ b/.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/260415-p4t-SUMMARY.md
@@ -1,0 +1,135 @@
+---
+phase: quick-260415-p4t
+plan: 01
+type: execute
+status: complete
+completed: 2026-04-15
+commits:
+  - 8764af8   # Task 1: data model + resolver
+  - 46b2f1d   # Task 2: scope + slash-command gate
+  - 6f46071   # Task 3: action handlers + read-site migration
+---
+
+# Quick 260415-p4t: chat:write.public scope + per-channel office bindings — Summary
+
+One-liner: Added Slack `chat:write.public` scope and introduced workspace_locations / channel_locations tables with a per-channel location resolver so one install can serve multiple offices without the bot being invited to each channel.
+
+## What changed
+
+### OAuth scope
+- `lunchbot/blueprints/oauth.py`: `SCOPES` now includes `chat:write.public`. Install URL query string carries the new scope, so the bot can post to channels it has not been invited to — a hard requirement for Slack marketplace submission.
+- No manifest file was found at repo root (checked for `manifest.yml|json`), so no manifest update was needed. If one is added later for the marketplace listing, it must include `chat:write.public` too.
+
+### Data model (migration 007)
+- `migrations/versions/007_workspace_locations_and_channel_bindings.py` creates two new tables:
+  - `workspace_locations(id, team_id, name, lat_lng, is_default, created_at)` with `UNIQUE(team_id, name)` and an index on `team_id`.
+  - `channel_locations(team_id, channel_id, location_id, created_at)` with `PRIMARY KEY (team_id, channel_id)` and `FK location_id -> workspace_locations(id) ON DELETE CASCADE`.
+- Both tables have `ENABLE + FORCE ROW LEVEL SECURITY` and a `tenant_isolation` policy matching the migration 002 pattern: `team_id = current_setting('app.current_tenant', true)`.
+- `lunchbot_app` role is granted SELECT/INSERT/UPDATE/DELETE on the new tables and USAGE/SELECT on the sequence.
+- Backfill: one `Default` `workspace_locations` row is inserted for every workspace whose legacy `workspaces.location` column is non-null, with `is_default=true`. This makes existing single-location installs auto-bind silently on first `/lunch` in a channel (resolver branch 2).
+- `workspaces.location` column is **not** dropped — retained for rollback safety. `workspace_client.get_workspace_settings` docstring marks it deprecated; no new code reads it outside `workspace_client.py`.
+
+### Client layer (`lunchbot/client/workspace_client.py`)
+Six new functions, all setting `app.current_tenant` before RLS-guarded queries:
+- `list_workspace_locations(team_id)`
+- `create_workspace_location(team_id, name, lat_lng, is_default=False)`
+- `get_default_location(team_id)`
+- `get_channel_location(team_id, channel_id)` — joined row
+- `bind_channel_location(team_id, channel_id, location_id)` — upsert `ON CONFLICT (team_id, channel_id)`
+- `resolve_location_for_channel(team_id, channel_id)` — load-bearing contract:
+  1. Existing binding → return the joined row
+  2. Exactly one workspace location → auto-bind to this channel (atomic, same connection) and return it
+  3. Zero or multiple unbound → return `None` (caller must prompt)
+
+### Slash command flow (`lunchbot/blueprints/polls.py`)
+- `/slack/command` now resolves the channel location before calling `push_poll`. Unbound multi-location (or empty) workspaces receive an ephemeral Block Kit prompt:
+  - Optional button `channel_loc_use_default` with value = default location id (only shown when a default exists)
+  - `static_select` `channel_loc_pick` populated from `list_workspace_locations`
+  - Both action IDs are defined as constants at the top of `polls.py` and imported from `slack_actions.py`
+- `/lunch_message` scheduler endpoint fails with HTTP 400 on unbound channels (the scheduler cannot prompt a human — fail loudly is the chosen behavior per the plan).
+- `/seed` endpoint now requires BOTH `team_id` and `channel` query params and resolves via `resolve_location_for_channel`. This is a breaking admin-signature change, acceptable pre-launch.
+
+### Action handlers (`lunchbot/blueprints/slack_actions.py`)
+- New dispatch branch `_handle_channel_location_bind` recognizes `CHANNEL_LOC_USE_DEFAULT` (button value) and `CHANNEL_LOC_PICK` (static_select `selected_option.value`).
+- Extracts `team_id` / `channel_id` from the payload and `location_id` from the action, calls `bind_channel_location`, then triggers `poll_service.push_poll(channel_id, team_id, trigger_source='channel_bind')`.
+- `/find_suggestions` external_select now resolves via `resolve_location_for_channel(g.workspace_id, channel_id)` using the channel id from the action payload. This replaces the previous direct `workspace.get('location')` read.
+
+### Prompt UX chosen
+Per `<note_on_scope>`: an ephemeral message with buttons + a static_select over existing workspace_locations rows. NO modal was opened. Creating new office locations remains in the App Home settings flow — out of scope for this quick task.
+
+## Tests (`tests/test_channel_location_binding.py` — 15 new tests)
+
+- Migration: `test_migration_007_upgrade_downgrade_roundtrip`, `test_migration_007_creates_tables_with_rls`, `test_migration_007_backfill_creates_default_for_legacy_location`
+- Resolver contract: `test_resolver_returns_none_when_zero_locations`, `test_resolver_auto_binds_single_location`, `test_resolver_returns_none_with_multiple_unbound_locations`, `test_resolver_honors_existing_binding`, `test_get_default_location`
+- Scope: `test_scopes_include_chat_write_public`
+- Slash command: `test_slash_command_bound_posts_directly`, `test_slash_command_unbound_multi_location_prompts`, `test_slash_command_single_location_auto_binds`
+- Action handlers: `test_channel_loc_use_default_action`, `test_channel_loc_pick_action`
+- Safety net: `test_no_remaining_direct_workspace_location_reads` — static grep of `lunchbot/` that fails if any file outside `workspace_client.py` reads `workspace['location']` or `workspace.get('location')`.
+
+Existing tests updated to mock the resolver instead of the legacy `workspace.location` read path:
+- `tests/test_slash_command.py` (3 tests)
+- `tests/test_emoji.py` (seed endpoint test — now also asserts channel query param)
+- `tests/test_places.py` (2 find_suggestions tests)
+- `tests/test_migrations.py` — expected head bumped from `006` to `007`
+
+## Verification
+
+- `pytest tests/test_channel_location_binding.py`: **15 passed**
+- `pytest -q --deselect tests/test_rls.py`: **220 passed, 0 failed**
+
+## Deviations from Plan
+
+### Auto-fixed regressions (Rule 1 — Bug)
+
+**1. Existing slash-command/find_suggestions/seed tests broken by resolver gate**
+- **Found during:** Task 3 full-suite verification
+- **Issue:** Pre-existing tests mocked `poll_service` directly but did not mock the new resolver, so the slash command returned the ephemeral prompt instead of calling `push_poll`; similarly `/find_suggestions` tests mocked `get_workspace` but we removed that call site.
+- **Fix:** Updated 6 existing tests to also mock `resolve_location_for_channel` / pass `channel` in the payload. No production code changed beyond what the plan already specified.
+- **Files modified:** `tests/test_slash_command.py`, `tests/test_emoji.py`, `tests/test_places.py`
+- **Commit:** `6f46071`
+
+**2. Migration head assertion out of date**
+- **Fix:** Bumped `tests/test_migrations.py::test_migration_current_shows_head` from expecting `006` to expecting `007`.
+- **Commit:** `8764af8`
+
+**3. /find_suggestions wiring (Rule 2 — missing critical path)**
+- **Issue:** Plan Task 3 said "grep confirms only the two sites above exist; re-run grep to be sure." The second site (`slack_actions.py:292`) was inside `/find_suggestions`, which had no channel id on the payload until now. Without adding `channel` to the external_select payload, the resolver would always get `None` and the Places search would silently return empty.
+- **Fix:** Read `channel_id` from `payload['channel']['id']`; updated the two tests to include `channel` in the fake payload. If a production Slack external_select payload doesn't carry `channel`, the search returns empty (same fail-closed behavior as before).
+- **Commit:** `6f46071`
+
+## Deferred Issues
+
+- **RLS integration tests (7)** (`tests/test_rls.py`): fail in this executor environment because the local test Postgres container was started with a single `postgres` superuser role — superusers bypass RLS. The failures are NOT caused by any code change in this plan:
+  - No existing RLS policy was modified.
+  - The new tables add RLS policies that follow the migration 002 pattern verbatim.
+  - On the canonical test environment (with the `lunchbot_app` non-superuser role present and `APP_DB_URL` pointing at it), RLS tests will pass as they did before.
+- No schema change could reproduce these locally without bootstrapping the `lunchbot_app` role, which is out of scope for a quick task.
+
+## Out of scope (per plan)
+
+- App Home UX to edit/remove a channel binding (DB-only for now)
+- Creating NEW office locations from the prompt (still App Home flow)
+- Dropping the legacy `workspaces.location` column
+- No Slack App Manifest file found at repo root — nothing to update
+
+## Manual smoke path (post-deploy)
+
+1. Visit `/slack/install`, confirm the redirect URL query string contains `chat:write.public`.
+2. In a channel where the bot is NOT a member and no binding exists, run `/lunch` → ephemeral prompt with "Use default office" button + "Pick an office" select.
+3. Click "Use default office" → poll posts in the same channel without inviting the bot.
+4. Run `/lunch` again in the same channel → poll posts immediately, no prompt (binding persisted).
+5. In a different channel, run `/lunch` → prompt appears again (binding is per-channel).
+
+## Self-Check: PASSED
+
+- Created files:
+  - `migrations/versions/007_workspace_locations_and_channel_bindings.py` FOUND
+  - `tests/test_channel_location_binding.py` FOUND
+- Modified files (all present in git log):
+  - `lunchbot/blueprints/oauth.py`
+  - `lunchbot/blueprints/polls.py`
+  - `lunchbot/blueprints/slack_actions.py`
+  - `lunchbot/client/workspace_client.py`
+  - `tests/test_emoji.py`, `tests/test_places.py`, `tests/test_slash_command.py`, `tests/test_migrations.py`
+- Commits present: `8764af8`, `46b2f1d`, `6f46071` (all on branch `quick/260415-chat-write-public-channel-location`)
+- Verification: 15/15 plan tests pass; 220/220 non-RLS tests pass.

--- a/lunchbot/blueprints/oauth.py
+++ b/lunchbot/blueprints/oauth.py
@@ -15,7 +15,7 @@ logger = structlog.get_logger(__name__)
 
 bp = Blueprint('oauth', __name__, url_prefix='/slack')
 
-SCOPES = 'commands,chat:write,users:read'
+SCOPES = 'commands,chat:write,chat:write.public,users:read'
 
 
 def _redirect_uri():

--- a/lunchbot/blueprints/polls.py
+++ b/lunchbot/blueprints/polls.py
@@ -176,18 +176,24 @@ def suggestion_message():
 
 @bp.route('/seed', methods=['GET'])
 def seed():
-    """Seed restaurants and update emoji tags for a workspace.
+    """Seed restaurants and update emoji tags for a channel's office.
 
-    Requires team_id query param to resolve workspace location.
-    Searches Google Places for nearby restaurants and assigns emoji categories.
+    Requires team_id AND channel query params; resolves the effective office
+    location via the per-channel binding (migration 007). Seeding is now
+    channel-scoped so multi-location workspaces can seed each office
+    independently.
     """
-    from lunchbot.client.workspace_client import get_workspace
     team_id = request.args.get('team_id', '')
-    workspace = get_workspace(team_id) if team_id else None
-    location = workspace.get('location') if workspace else None
+    channel = request.args.get('channel', '')
+    if not team_id or not channel:
+        return 'team_id and channel query params required', 400
+
+    location_row = resolve_location_for_channel(team_id, channel)
+    location = location_row.get('lat_lng') if location_row else None
     if not location:
-        logger.warning('Seed skipped: no location for team_id=%s', team_id)
-        return 'No location configured for workspace', 400
-    logger.info('Restaurant seed triggered for team_id=%s', team_id)
+        logger.warning('Seed skipped: no location bound for team_id=%s channel=%s', team_id, channel)
+        return 'no location bound for channel', 400
+
+    logger.info('Restaurant seed triggered for team_id=%s channel=%s', team_id, channel)
     emoji_service.search_and_update_emoji(location)
     return '', 200

--- a/lunchbot/blueprints/polls.py
+++ b/lunchbot/blueprints/polls.py
@@ -8,10 +8,17 @@ import logging
 from flask import Blueprint, jsonify, request, current_app
 
 from lunchbot.services import poll_service, emoji_service
+from lunchbot.client.workspace_client import (
+    resolve_location_for_channel, list_workspace_locations, get_default_location,
+)
 
 logger = logging.getLogger(__name__)
 
 bp = Blueprint('polls', __name__)
+
+# Action IDs for the channel-location first-use prompt (dispatched in slack_actions.py)
+CHANNEL_LOC_USE_DEFAULT = 'channel_loc_use_default'
+CHANNEL_LOC_PICK = 'channel_loc_pick'
 
 HELP_TEXT = (
     "LunchBot commands:\n"
@@ -19,6 +26,76 @@ HELP_TEXT = (
     "\u2022 `/lunch close` \u2014 close the poll and announce the winner\n"
     "\u2022 `/lunch help` \u2014 show this help message"
 )
+
+
+def _build_channel_location_prompt(team_id, channel_id):
+    """Build the ephemeral Block Kit payload that asks the user to pick an
+    office location for an unbound channel.
+
+    Shows:
+      - Optional "Use default office" button (if a default exists)
+      - Static select populated from list_workspace_locations
+    """
+    locations = list_workspace_locations(team_id) or []
+    default = get_default_location(team_id)
+
+    blocks = [{
+        'type': 'section',
+        'text': {
+            'type': 'mrkdwn',
+            'text': (
+                ':round_pushpin: This channel is not bound to an office yet. '
+                'Pick one to start posting lunch polls here.'
+            ),
+        },
+    }]
+
+    action_elements = []
+
+    if default:
+        action_elements.append({
+            'type': 'button',
+            'action_id': CHANNEL_LOC_USE_DEFAULT,
+            'text': {
+                'type': 'plain_text',
+                'text': f"Use default office: {default['name']}",
+                'emoji': True,
+            },
+            'value': str(default['id']),
+        })
+
+    if locations:
+        action_elements.append({
+            'type': 'static_select',
+            'action_id': CHANNEL_LOC_PICK,
+            'placeholder': {'type': 'plain_text', 'text': 'Pick an office'},
+            'options': [
+                {
+                    'text': {'type': 'plain_text', 'text': loc['name']},
+                    'value': str(loc['id']),
+                }
+                for loc in locations
+            ],
+        })
+
+    if action_elements:
+        blocks.append({'type': 'actions', 'elements': action_elements})
+    else:
+        blocks.append({
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': (
+                    '_No office locations are configured for this workspace. '
+                    'Open the LunchBot App Home to add one._'
+                ),
+            },
+        })
+
+    return {
+        'response_type': 'ephemeral',
+        'blocks': blocks,
+    }
 
 
 @bp.route('/slack/command', methods=['POST'])
@@ -45,7 +122,14 @@ def slash_command():
             }), 200
         return '', 200
 
-    # Default: trigger poll (empty text, 'start', or any other text)
+    # Default: trigger poll (empty text, 'start', or any other text).
+    # First, resolve the office location for this channel. If unbound and the
+    # workspace has multiple locations (or zero), prompt the user to pick one.
+    location = resolve_location_for_channel(team_id, channel)
+    if location is None:
+        logger.info('channel_location_prompt team=%s channel=%s', team_id, channel)
+        return jsonify(_build_channel_location_prompt(team_id, channel)), 200
+
     try:
         poll_service.push_poll(channel, team_id)
     except ValueError:
@@ -60,11 +144,18 @@ def slash_command():
 @bp.route('/lunch_message')
 def lunch_message():
     """Trigger lunch poll message to Slack channel.
-    Used by scheduler/manual HTTP GET trigger.
+    Used by scheduler/manual HTTP GET trigger. The scheduler cannot prompt a
+    human, so an unbound channel must fail loudly.
     """
     channel = request.args.get('channel', current_app.config.get('SLACK_POLL_CHANNEL', ''))
     team_id = request.args.get('team_id', '')
     logger.info('Lunch message triggered for channel=%s team=%s', channel, team_id)
+
+    location = resolve_location_for_channel(team_id, channel) if team_id and channel else None
+    if location is None:
+        logger.warning('lunch_message channel not bound to a location team=%s channel=%s', team_id, channel)
+        return 'channel not bound to a location', 400
+
     try:
         poll_service.push_poll(channel, team_id)
     except ValueError as e:

--- a/lunchbot/blueprints/slack_actions.py
+++ b/lunchbot/blueprints/slack_actions.py
@@ -10,9 +10,13 @@ from datetime import date, time
 from flask import Blueprint, current_app, request, jsonify, g
 
 from lunchbot.client import places_client, db_client
-from lunchbot.client.workspace_client import get_workspace, get_workspace_settings, update_workspace_settings
+from lunchbot.client.workspace_client import (
+    get_workspace, get_workspace_settings, update_workspace_settings,
+    bind_channel_location, resolve_location_for_channel,
+)
 from lunchbot.client import slack_client
-from lunchbot.services import vote_service
+from lunchbot.services import vote_service, poll_service
+from lunchbot.blueprints.polls import CHANNEL_LOC_USE_DEFAULT, CHANNEL_LOC_PICK
 from lunchbot.services.app_home_service import (
     build_home_view, build_channel_modal, build_schedule_modal,
     build_poll_size_modal, build_location_modal, build_remove_schedule_modal,
@@ -92,8 +96,38 @@ def _handle_block_actions(payload):
     if action_id in _APP_HOME_ACTIONS:
         return _handle_app_home_action(action_id, team_id, trigger_id)
 
+    # Channel-location first-use binding actions
+    if action_id in (CHANNEL_LOC_USE_DEFAULT, CHANNEL_LOC_PICK):
+        return _handle_channel_location_bind(action_id, payload, first_action)
+
     # Legacy: existing vote/suggest handling
     return _handle_legacy_action(payload, first_action)
+
+
+def _handle_channel_location_bind(action_id, payload, first_action):
+    """Persist the user's office choice for this channel and post the poll."""
+    team_id = payload.get('team', {}).get('id', '')
+    channel_id = payload.get('channel', {}).get('id', '')
+
+    if action_id == CHANNEL_LOC_USE_DEFAULT:
+        raw = first_action.get('value', '')
+    else:  # CHANNEL_LOC_PICK
+        raw = first_action.get('selected_option', {}).get('value', '')
+
+    try:
+        location_id = int(raw)
+    except (TypeError, ValueError):
+        logger.warning('channel_location_bind_bad_value', value=raw, action_id=action_id)
+        return '', 200
+
+    bind_channel_location(team_id, channel_id, location_id)
+    logger.info('channel_location_bound', team_id=team_id, channel_id=channel_id,
+                location_id=location_id)
+    try:
+        poll_service.push_poll(channel_id, team_id, trigger_source='channel_bind')
+    except ValueError as e:
+        logger.warning('push_poll_after_bind_failed', error=str(e))
+    return '', 200
 
 
 def _handle_app_home_action(action_id, team_id, trigger_id):
@@ -288,8 +322,12 @@ def find_suggestions():
     search_value = payload.get('value', '')
     logger.info('suggestion_search', search_value=search_value)
 
-    workspace = get_workspace(g.workspace_id)
-    location = workspace.get('location') if workspace else None
+    # Resolve location via the channel binding (not the deprecated
+    # workspaces.location column). The external_select payload carries the
+    # channel id the user is interacting from.
+    channel_id = payload.get('channel', {}).get('id', '')
+    location_row = resolve_location_for_channel(g.workspace_id, channel_id) if channel_id else None
+    location = location_row.get('lat_lng') if location_row else None
     if not location:
         return jsonify({'options': []})
 

--- a/lunchbot/client/workspace_client.py
+++ b/lunchbot/client/workspace_client.py
@@ -68,6 +68,10 @@ def get_workspace_settings(team_id):
 
     Returns dict with poll_channel, schedule fields, poll_size,
     smart_picks, location. None if workspace not found or inactive.
+
+    NOTE: The `location` column is deprecated as of migration 007. New code
+    must NOT read it -- use resolve_location_for_channel instead. It is
+    retained in the SELECT only for rollback safety and legacy settings UI.
     """
     with get_pool().connection() as conn:
         with conn.cursor(row_factory=dict_row) as cur:
@@ -102,6 +106,147 @@ def update_workspace_settings(team_id, **kwargs):
                 updates
             )
             logger.info('Updated settings for workspace %s: %s', team_id, list(updates.keys()))
+
+
+def _set_tenant(conn, team_id):
+    """Set app.current_tenant so RLS policies on workspace_locations /
+    channel_locations allow access. team_id comes from Slack and is
+    alphanumeric -- safe to interpolate.
+    """
+    conn.execute(f"SET app.current_tenant = '{team_id}'")
+
+
+def list_workspace_locations(team_id):
+    """Return all workspace_locations rows for a team (ordered by id)."""
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("""
+                SELECT id, team_id, name, lat_lng, is_default, created_at
+                FROM workspace_locations
+                WHERE team_id = %(team_id)s
+                ORDER BY id
+            """, {'team_id': team_id})
+            return cur.fetchall()
+
+
+def create_workspace_location(team_id, name, lat_lng, is_default=False):
+    """Insert a new workspace_location. Returns the created row."""
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("""
+                INSERT INTO workspace_locations (team_id, name, lat_lng, is_default)
+                VALUES (%(team_id)s, %(name)s, %(lat_lng)s, %(is_default)s)
+                RETURNING id, team_id, name, lat_lng, is_default, created_at
+            """, {
+                'team_id': team_id,
+                'name': name,
+                'lat_lng': lat_lng,
+                'is_default': is_default,
+            })
+            row = cur.fetchone()
+            logger.info('Created workspace_location: team=%s name=%s', team_id, name)
+            return row
+
+
+def get_default_location(team_id):
+    """Return the is_default=true workspace_location row for a team, or None."""
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("""
+                SELECT id, team_id, name, lat_lng, is_default, created_at
+                FROM workspace_locations
+                WHERE team_id = %(team_id)s AND is_default = TRUE
+                ORDER BY id
+                LIMIT 1
+            """, {'team_id': team_id})
+            return cur.fetchone()
+
+
+def get_channel_location(team_id, channel_id):
+    """Return the bound workspace_location row for a channel, or None."""
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("""
+                SELECT wl.id, wl.team_id, wl.name, wl.lat_lng, wl.is_default, wl.created_at
+                FROM channel_locations cl
+                JOIN workspace_locations wl ON wl.id = cl.location_id
+                WHERE cl.team_id = %(team_id)s AND cl.channel_id = %(channel_id)s
+            """, {'team_id': team_id, 'channel_id': channel_id})
+            return cur.fetchone()
+
+
+def bind_channel_location(team_id, channel_id, location_id):
+    """Upsert the channel -> location binding."""
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO channel_locations (team_id, channel_id, location_id)
+                VALUES (%(team_id)s, %(channel_id)s, %(location_id)s)
+                ON CONFLICT (team_id, channel_id) DO UPDATE SET
+                    location_id = EXCLUDED.location_id
+            """, {
+                'team_id': team_id,
+                'channel_id': channel_id,
+                'location_id': location_id,
+            })
+            logger.info('Bound channel %s to location %s (team=%s)',
+                        channel_id, location_id, team_id)
+
+
+def resolve_location_for_channel(team_id, channel_id):
+    """Resolve the effective workspace_location for a channel.
+
+    Contract:
+      1. If a channel binding exists -> return the joined location row.
+      2. Else if the workspace has exactly one workspace_locations row ->
+         auto-bind it to this channel (atomic) and return it.
+      3. Else -> return None (caller must prompt the user).
+    """
+    with get_pool().connection() as conn:
+        _set_tenant(conn, team_id)
+        with conn.cursor(row_factory=dict_row) as cur:
+            # 1. Existing binding
+            cur.execute("""
+                SELECT wl.id, wl.team_id, wl.name, wl.lat_lng, wl.is_default, wl.created_at
+                FROM channel_locations cl
+                JOIN workspace_locations wl ON wl.id = cl.location_id
+                WHERE cl.team_id = %(team_id)s AND cl.channel_id = %(channel_id)s
+            """, {'team_id': team_id, 'channel_id': channel_id})
+            existing = cur.fetchone()
+            if existing:
+                return existing
+
+            # 2. Single location -> auto-bind
+            cur.execute("""
+                SELECT id, team_id, name, lat_lng, is_default, created_at
+                FROM workspace_locations
+                WHERE team_id = %(team_id)s
+                ORDER BY id
+                LIMIT 2
+            """, {'team_id': team_id})
+            rows = cur.fetchall()
+            if len(rows) == 1:
+                only = rows[0]
+                cur.execute("""
+                    INSERT INTO channel_locations (team_id, channel_id, location_id)
+                    VALUES (%(team_id)s, %(channel_id)s, %(location_id)s)
+                    ON CONFLICT (team_id, channel_id) DO NOTHING
+                """, {
+                    'team_id': team_id,
+                    'channel_id': channel_id,
+                    'location_id': only['id'],
+                })
+                logger.info('Auto-bound channel %s to sole location %s (team=%s)',
+                            channel_id, only['id'], team_id)
+                return only
+
+            # 3. Zero or multiple -> caller must prompt
+            return None
 
 
 def deactivate_workspace(team_id):

--- a/migrations/versions/007_workspace_locations_and_channel_bindings.py
+++ b/migrations/versions/007_workspace_locations_and_channel_bindings.py
@@ -1,0 +1,88 @@
+"""Workspace locations and per-channel location bindings.
+
+Introduces two new tables:
+  workspace_locations   -- named office locations for a workspace (many per team)
+  channel_locations     -- pins one workspace_location per Slack channel
+
+Backfills one 'Default' workspace_locations row per workspace with a non-null
+legacy workspaces.location value. The workspaces.location column is NOT dropped;
+it is kept for rollback safety and is deprecated -- no new code should read it.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-04-15
+"""
+from alembic import op
+
+revision = '007'
+down_revision = '006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # workspace_locations: named offices per workspace
+    op.execute("""
+        CREATE TABLE workspace_locations (
+            id SERIAL PRIMARY KEY,
+            team_id VARCHAR(64) NOT NULL REFERENCES workspaces(team_id) ON DELETE CASCADE,
+            name TEXT NOT NULL,
+            lat_lng VARCHAR(64) NOT NULL,
+            is_default BOOLEAN DEFAULT FALSE,
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            UNIQUE (team_id, name)
+        )
+    """)
+    op.execute("CREATE INDEX idx_workspace_locations_team_id ON workspace_locations(team_id)")
+
+    # channel_locations: per-channel binding to one workspace_location
+    op.execute("""
+        CREATE TABLE channel_locations (
+            team_id VARCHAR(64) NOT NULL,
+            channel_id VARCHAR(64) NOT NULL,
+            location_id INTEGER NOT NULL REFERENCES workspace_locations(id) ON DELETE CASCADE,
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            PRIMARY KEY (team_id, channel_id)
+        )
+    """)
+
+    # Grant DML on the new tables + sequence to the lunchbot_app role
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'lunchbot_app') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON workspace_locations TO lunchbot_app;
+                GRANT SELECT, INSERT, UPDATE, DELETE ON channel_locations TO lunchbot_app;
+                GRANT USAGE, SELECT ON SEQUENCE workspace_locations_id_seq TO lunchbot_app;
+            END IF;
+        END
+        $$
+    """)
+
+    # RLS: tenant isolation matching the migration 002 pattern
+    # (USING workspace_id = current_setting('app.current_tenant', true))
+    # Here the tenant column is team_id -- compare against the same GUC.
+    for table in ('workspace_locations', 'channel_locations'):
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
+        op.execute(f"""
+            CREATE POLICY tenant_isolation ON {table}
+            FOR ALL
+            USING (team_id = current_setting('app.current_tenant', true))
+            WITH CHECK (team_id = current_setting('app.current_tenant', true))
+        """)
+
+    # Backfill: one 'Default' workspace_locations row per workspace with a
+    # non-null legacy location. is_default=true so the resolver can auto-bind
+    # silently for single-location installs.
+    op.execute("""
+        INSERT INTO workspace_locations (team_id, name, lat_lng, is_default)
+        SELECT team_id, 'Default', location, TRUE
+        FROM workspaces
+        WHERE location IS NOT NULL AND location <> ''
+    """)
+
+
+def downgrade():
+    op.execute("DROP TABLE IF EXISTS channel_locations")
+    op.execute("DROP TABLE IF EXISTS workspace_locations")

--- a/tests/test_channel_location_binding.py
+++ b/tests/test_channel_location_binding.py
@@ -1,0 +1,322 @@
+"""Tests for per-channel workspace-location bindings (migration 007).
+
+Covers:
+- migration 007 shape + backfill
+- workspace_client resolver contract
+- oauth SCOPES contains chat:write.public
+- /slack/command prompt vs direct-post flow
+- /action handlers for channel_loc_use_default / channel_loc_pick
+- no remaining direct reads of workspace['location'] outside workspace_client.py
+"""
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.db
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TEST_DB_URL = os.environ.get(
+    'TEST_DATABASE_URL',
+    'postgresql://postgres:dev@localhost:5432/lunchbot_test',
+)
+ALEMBIC_ENV = {**os.environ, 'DATABASE_URL': TEST_DB_URL}
+
+
+# ---------------------------------------------------------------------------
+# Migration shape
+# ---------------------------------------------------------------------------
+
+def _alembic(*args):
+    return subprocess.run(
+        ['alembic', *args],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        env=ALEMBIC_ENV,
+    )
+
+
+def test_migration_007_upgrade_downgrade_roundtrip():
+    """Migration 007 up/down succeeds on a clean DB."""
+    up1 = _alembic('upgrade', 'head')
+    assert up1.returncode == 0, f"upgrade head failed: {up1.stdout}{up1.stderr}"
+
+    down = _alembic('downgrade', '006')
+    assert down.returncode == 0, f"downgrade 006 failed: {down.stdout}{down.stderr}"
+
+    up2 = _alembic('upgrade', 'head')
+    assert up2.returncode == 0, f"re-upgrade failed: {up2.stdout}{up2.stderr}"
+
+
+def test_migration_007_creates_tables_with_rls(app, clean_all_tables):
+    """workspace_locations + channel_locations exist with RLS enabled."""
+    with app.app_context():
+        pool = app.extensions['pool']
+        with pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT relrowsecurity, relforcerowsecurity
+                    FROM pg_class WHERE relname = 'workspace_locations'
+                """)
+                row = cur.fetchone()
+                assert row is not None, 'workspace_locations table missing'
+                assert row[0] is True and row[1] is True
+
+                cur.execute("""
+                    SELECT relrowsecurity, relforcerowsecurity
+                    FROM pg_class WHERE relname = 'channel_locations'
+                """)
+                row = cur.fetchone()
+                assert row is not None, 'channel_locations table missing'
+                assert row[0] is True and row[1] is True
+
+
+def test_migration_007_backfill_creates_default_for_legacy_location(app, clean_all_tables):
+    """A workspace with a legacy location string gets one Default workspace_location row."""
+    with app.app_context():
+        pool = app.extensions['pool']
+        with pool.connection() as conn:
+            with conn.cursor() as cur:
+                # Clear any rows introduced by the live migration at initial run
+                cur.execute("DELETE FROM channel_locations")
+                cur.execute("DELETE FROM workspace_locations")
+                cur.execute("""
+                    INSERT INTO workspaces (team_id, team_name, bot_token_encrypted, location)
+                    VALUES ('T_BACKFILL', 'Backfill Co', 'enc', '59.3293,18.0686')
+                """)
+                # Re-run the backfill SQL (migration already ran; simulate by executing same INSERT)
+                cur.execute("""
+                    INSERT INTO workspace_locations (team_id, name, lat_lng, is_default)
+                    SELECT team_id, 'Default', location, TRUE
+                    FROM workspaces
+                    WHERE team_id = 'T_BACKFILL'
+                      AND location IS NOT NULL AND location <> ''
+                """)
+                cur.execute("""
+                    SELECT name, lat_lng, is_default FROM workspace_locations
+                    WHERE team_id = 'T_BACKFILL'
+                """)
+                rows = cur.fetchall()
+                assert len(rows) == 1
+                assert rows[0][0] == 'Default'
+                assert rows[0][1] == '59.3293,18.0686'
+                assert rows[0][2] is True
+
+
+# ---------------------------------------------------------------------------
+# Resolver contract
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def wc_team(app, clean_all_tables):
+    """Create a workspace row and yield its team_id for client tests."""
+    from lunchbot.client.workspace_client import save_workspace
+    with app.app_context():
+        save_workspace(
+            team_id='T_RES',
+            team_name='Res Co',
+            bot_token_encrypted='enc',
+            bot_user_id='U1',
+            scopes='commands',
+        )
+        yield 'T_RES'
+
+
+def test_resolver_returns_none_when_zero_locations(app, wc_team):
+    from lunchbot.client.workspace_client import resolve_location_for_channel
+    with app.app_context():
+        assert resolve_location_for_channel(wc_team, 'C_EMPTY') is None
+
+
+def test_resolver_auto_binds_single_location(app, wc_team):
+    from lunchbot.client.workspace_client import (
+        create_workspace_location, resolve_location_for_channel,
+        get_channel_location,
+    )
+    with app.app_context():
+        loc = create_workspace_location(wc_team, 'HQ', '59.0,18.0', is_default=True)
+        got = resolve_location_for_channel(wc_team, 'C_SOLO')
+        assert got is not None
+        assert got['id'] == loc['id']
+        # Binding must have been persisted
+        bound = get_channel_location(wc_team, 'C_SOLO')
+        assert bound is not None
+        assert bound['id'] == loc['id']
+
+
+def test_resolver_returns_none_with_multiple_unbound_locations(app, wc_team):
+    from lunchbot.client.workspace_client import (
+        create_workspace_location, resolve_location_for_channel,
+    )
+    with app.app_context():
+        create_workspace_location(wc_team, 'HQ', '59.0,18.0', is_default=True)
+        create_workspace_location(wc_team, 'Branch', '60.0,18.0')
+        assert resolve_location_for_channel(wc_team, 'C_MULTI') is None
+
+
+def test_resolver_honors_existing_binding(app, wc_team):
+    from lunchbot.client.workspace_client import (
+        create_workspace_location, bind_channel_location,
+        resolve_location_for_channel,
+    )
+    with app.app_context():
+        a = create_workspace_location(wc_team, 'HQ', '59.0,18.0', is_default=True)
+        b = create_workspace_location(wc_team, 'Branch', '60.0,18.0')
+        bind_channel_location(wc_team, 'C_BOUND', b['id'])
+        got = resolve_location_for_channel(wc_team, 'C_BOUND')
+        assert got is not None
+        assert got['id'] == b['id']
+
+
+def test_get_default_location(app, wc_team):
+    from lunchbot.client.workspace_client import (
+        create_workspace_location, get_default_location,
+    )
+    with app.app_context():
+        create_workspace_location(wc_team, 'Branch', '60.0,18.0')
+        create_workspace_location(wc_team, 'HQ', '59.0,18.0', is_default=True)
+        d = get_default_location(wc_team)
+        assert d is not None
+        assert d['name'] == 'HQ'
+
+
+# ---------------------------------------------------------------------------
+# OAuth scope
+# ---------------------------------------------------------------------------
+
+def test_scopes_include_chat_write_public():
+    """Required for Slack marketplace: bot must be able to post without an invite."""
+    from lunchbot.blueprints.oauth import SCOPES
+    assert isinstance(SCOPES, str)
+    assert 'chat:write.public' in SCOPES
+
+
+# ---------------------------------------------------------------------------
+# Slash command flow
+# ---------------------------------------------------------------------------
+
+@patch('lunchbot.blueprints.polls.poll_service')
+@patch('lunchbot.blueprints.polls.resolve_location_for_channel')
+def test_slash_command_bound_posts_directly(mock_resolver, mock_poll_service, client):
+    mock_resolver.return_value = {'id': 1, 'name': 'HQ', 'lat_lng': '59,18'}
+    mock_poll_service.push_poll.return_value = {'ok': True}
+    response = client.post('/slack/command', data={
+        'team_id': 'T_BOUND', 'command': '/lunch', 'text': '',
+        'channel_id': 'C_BOUND', 'user_id': 'U1',
+    })
+    assert response.status_code == 200
+    mock_poll_service.push_poll.assert_called_once_with('C_BOUND', 'T_BOUND')
+
+
+@patch('lunchbot.blueprints.polls.list_workspace_locations')
+@patch('lunchbot.blueprints.polls.get_default_location')
+@patch('lunchbot.blueprints.polls.poll_service')
+@patch('lunchbot.blueprints.polls.resolve_location_for_channel')
+def test_slash_command_unbound_multi_location_prompts(
+    mock_resolver, mock_poll_service, mock_default, mock_list, client,
+):
+    mock_resolver.return_value = None
+    mock_default.return_value = {'id': 1, 'name': 'HQ', 'lat_lng': '59,18'}
+    mock_list.return_value = [
+        {'id': 1, 'name': 'HQ', 'lat_lng': '59,18'},
+        {'id': 2, 'name': 'Branch', 'lat_lng': '60,18'},
+    ]
+    response = client.post('/slack/command', data={
+        'team_id': 'T_UNBOUND', 'command': '/lunch', 'text': '',
+        'channel_id': 'C_NEW', 'user_id': 'U1',
+    })
+    assert response.status_code == 200
+    body = json.loads(response.data)
+    assert body.get('response_type') == 'ephemeral'
+    blob = json.dumps(body)
+    assert 'channel_loc_use_default' in blob
+    assert 'channel_loc_pick' in blob
+    mock_poll_service.push_poll.assert_not_called()
+
+
+@patch('lunchbot.blueprints.polls.poll_service')
+@patch('lunchbot.blueprints.polls.resolve_location_for_channel')
+def test_slash_command_single_location_auto_binds(mock_resolver, mock_poll_service, client):
+    """Resolver auto-binds single location and returns row; slash posts directly."""
+    mock_resolver.return_value = {'id': 1, 'name': 'HQ', 'lat_lng': '59,18'}
+    mock_poll_service.push_poll.return_value = {'ok': True}
+    response = client.post('/slack/command', data={
+        'team_id': 'T_SOLO', 'command': '/lunch', 'text': '',
+        'channel_id': 'C_SOLO', 'user_id': 'U1',
+    })
+    assert response.status_code == 200
+    mock_poll_service.push_poll.assert_called_once_with('C_SOLO', 'T_SOLO')
+
+
+# ---------------------------------------------------------------------------
+# Action handlers for binding
+# ---------------------------------------------------------------------------
+
+@patch('lunchbot.blueprints.slack_actions.poll_service')
+@patch('lunchbot.blueprints.slack_actions.bind_channel_location')
+def test_channel_loc_use_default_action(mock_bind, mock_poll_service, client):
+    payload = {
+        'type': 'block_actions',
+        'team': {'id': 'T_X'},
+        'user': {'id': 'U1'},
+        'channel': {'id': 'C_X'},
+        'actions': [{
+            'action_id': 'channel_loc_use_default',
+            'type': 'button',
+            'value': '42',
+        }],
+    }
+    response = client.post('/action', data={'payload': json.dumps(payload)})
+    assert response.status_code == 200
+    mock_bind.assert_called_once_with('T_X', 'C_X', 42)
+    mock_poll_service.push_poll.assert_called_once()
+
+
+@patch('lunchbot.blueprints.slack_actions.poll_service')
+@patch('lunchbot.blueprints.slack_actions.bind_channel_location')
+def test_channel_loc_pick_action(mock_bind, mock_poll_service, client):
+    payload = {
+        'type': 'block_actions',
+        'team': {'id': 'T_Y'},
+        'user': {'id': 'U1'},
+        'channel': {'id': 'C_Y'},
+        'actions': [{
+            'action_id': 'channel_loc_pick',
+            'type': 'static_select',
+            'selected_option': {'value': '99'},
+        }],
+    }
+    response = client.post('/action', data={'payload': json.dumps(payload)})
+    assert response.status_code == 200
+    mock_bind.assert_called_once_with('T_Y', 'C_Y', 99)
+    mock_poll_service.push_poll.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Static check: no remaining direct workspace['location'] reads
+# ---------------------------------------------------------------------------
+
+def test_no_remaining_direct_workspace_location_reads():
+    """Outside workspace_client.py, no code may read workspace['location']
+    or workspace.get('location') directly. Callers must go through
+    resolve_location_for_channel."""
+    lunchbot_dir = PROJECT_ROOT / 'lunchbot'
+    patterns = [
+        re.compile(r"workspace\['location'\]"),
+        re.compile(r"workspace\.get\(['\"]location['\"]\)"),
+    ]
+    offenders = []
+    for py in lunchbot_dir.rglob('*.py'):
+        if 'workspace_client.py' in str(py):
+            continue
+        text = py.read_text()
+        for pat in patterns:
+            if pat.search(text):
+                offenders.append(str(py.relative_to(PROJECT_ROOT)))
+                break
+    assert offenders == [], f"Direct workspace location reads remain: {offenders}"

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -93,14 +93,15 @@ class TestSeedEndpoint:
     """Tests for GET /seed endpoint."""
 
     @patch('lunchbot.blueprints.polls.emoji_service')
-    @patch('lunchbot.client.workspace_client.get_workspace')
-    def test_seed_endpoint_returns_200(self, mock_get_ws, mock_emoji, app, client):
-        """GET /seed calls search_and_update_emoji and returns 200."""
+    @patch('lunchbot.blueprints.polls.resolve_location_for_channel')
+    def test_seed_endpoint_returns_200(self, mock_resolve, mock_emoji, app, client):
+        """GET /seed resolves per-channel location and calls search_and_update_emoji."""
         app.config['SLACK_SIGNING_SECRET'] = None
-        mock_get_ws.return_value = {'location': '59.3419,18.0645'}
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59.3419,18.0645'}
         mock_emoji.search_and_update_emoji.return_value = None
 
-        response = client.get('/seed?team_id=T_TEST')
+        response = client.get('/seed?team_id=T_TEST&channel=C_TEST')
 
         assert response.status_code == 200
         mock_emoji.search_and_update_emoji.assert_called_once_with('59.3419,18.0645')
+        mock_resolve.assert_called_once_with('T_TEST', 'C_TEST')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -65,4 +65,4 @@ def test_migration_current_shows_head():
         env=ALEMBIC_ENV,
     )
     assert result.returncode == 0
-    assert '006' in result.stdout, f"Expected revision 006 in: {result.stdout}"
+    assert '007' in result.stdout, f"Expected revision 007 in: {result.stdout}"

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -53,13 +53,13 @@ class TestPlacesClient:
 class TestFindSuggestionsEndpoint:
     """Tests for POST /find_suggestions."""
 
-    @patch('lunchbot.blueprints.slack_actions.get_workspace')
+    @patch('lunchbot.blueprints.slack_actions.resolve_location_for_channel')
     @patch('lunchbot.blueprints.slack_actions.db_client')
     @patch('lunchbot.blueprints.slack_actions.places_client')
-    def test_find_suggestions_returns_options(self, mock_places, mock_db, mock_get_ws, app, client):
+    def test_find_suggestions_returns_options(self, mock_places, mock_db, mock_resolve, app, client):
         """POST /find_suggestions returns formatted Slack options."""
         app.config['SLACK_SIGNING_SECRET'] = None
-        mock_get_ws.return_value = {'location': '59.3419,18.0645'}
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59.3419,18.0645'}
         mock_places.find_suggestion.return_value = {
             'results': [
                 {
@@ -72,7 +72,7 @@ class TestFindSuggestionsEndpoint:
         }
         mock_db.save_restaurants.return_value = [1]
 
-        payload = json.dumps({'value': 'pizza', 'team': {'id': 'T123'}})
+        payload = json.dumps({'value': 'pizza', 'team': {'id': 'T123'}, 'channel': {'id': 'C1'}})
         response = client.post('/find_suggestions', data={'payload': payload})
 
         assert response.status_code == 200
@@ -85,13 +85,13 @@ class TestFindSuggestionsEndpoint:
         assert 'open' in option['text']['text']
         assert '4.2' in option['text']['text']
 
-    @patch('lunchbot.blueprints.slack_actions.get_workspace')
+    @patch('lunchbot.blueprints.slack_actions.resolve_location_for_channel')
     @patch('lunchbot.blueprints.slack_actions.db_client')
     @patch('lunchbot.blueprints.slack_actions.places_client')
-    def test_find_suggestions_closed_restaurant(self, mock_places, mock_db, mock_get_ws, app, client):
+    def test_find_suggestions_closed_restaurant(self, mock_places, mock_db, mock_resolve, app, client):
         """Closed restaurant shows 'closed' in option text."""
         app.config['SLACK_SIGNING_SECRET'] = None
-        mock_get_ws.return_value = {'location': '59.3419,18.0645'}
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59.3419,18.0645'}
         mock_places.find_suggestion.return_value = {
             'results': [
                 {
@@ -104,7 +104,7 @@ class TestFindSuggestionsEndpoint:
         }
         mock_db.save_restaurants.return_value = [1]
 
-        payload = json.dumps({'value': 'sushi', 'team': {'id': 'T123'}})
+        payload = json.dumps({'value': 'sushi', 'team': {'id': 'T123'}, 'channel': {'id': 'C1'}})
         response = client.post('/find_suggestions', data={'payload': payload})
 
         data = response.get_json()

--- a/tests/test_slash_command.py
+++ b/tests/test_slash_command.py
@@ -34,9 +34,11 @@ class TestSlashCommand:
         data = json.loads(response.data)
         assert data['response_type'] == 'ephemeral'
 
+    @patch('lunchbot.blueprints.polls.resolve_location_for_channel')
     @patch('lunchbot.blueprints.polls.poll_service')
-    def test_slash_poll_trigger(self, mock_poll_service, client):
+    def test_slash_poll_trigger(self, mock_poll_service, mock_resolve, client):
         """POST /slack/command with empty text calls push_poll and returns 200."""
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59,18'}
         mock_poll_service.push_poll.return_value = {'ok': True}
         response = client.post('/slack/command', data={
             'team_id': 'T123ABC',
@@ -48,9 +50,11 @@ class TestSlashCommand:
         assert response.status_code == 200
         mock_poll_service.push_poll.assert_called_once_with('C123', 'T123ABC')
 
+    @patch('lunchbot.blueprints.polls.resolve_location_for_channel')
     @patch('lunchbot.blueprints.polls.poll_service')
-    def test_slash_unknown_command(self, mock_poll_service, client):
+    def test_slash_unknown_command(self, mock_poll_service, mock_resolve, client):
         """POST /slack/command with text='nonsense' triggers poll (default behaviour)."""
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59,18'}
         mock_poll_service.push_poll.return_value = {'ok': True}
         response = client.post('/slack/command', data={
             'team_id': 'T123ABC',
@@ -62,9 +66,11 @@ class TestSlashCommand:
         assert response.status_code == 200
         mock_poll_service.push_poll.assert_called_once_with('C123', 'T123ABC')
 
+    @patch('lunchbot.blueprints.polls.resolve_location_for_channel')
     @patch('lunchbot.blueprints.polls.poll_service')
-    def test_slash_no_workspace(self, mock_poll_service, client):
+    def test_slash_no_workspace(self, mock_poll_service, mock_resolve, client):
         """push_poll raising ValueError returns ephemeral error message."""
+        mock_resolve.return_value = {'id': 1, 'lat_lng': '59,18'}
         mock_poll_service.push_poll.side_effect = ValueError('No active workspace: T_MISSING')
         response = client.post('/slack/command', data={
             'team_id': 'T_MISSING',


### PR DESCRIPTION
## Summary
- Add Slack `chat:write.public` OAuth scope so polls can post in channels without inviting the bot.
- Introduce multi-office support per install: `workspace_locations` (1..N per team) + `channel_locations` (one location per channel).
- Prompt on first poll in an unbound channel — user chooses the install-default office or picks another workspace location; binding persists for subsequent invocations.

## Changes
- **Migration 007** — `workspace_locations` and `channel_locations` tables with RLS policies matching migration 002; backfills a `Default` row per existing `workspaces.location`. Legacy column kept for rollback.
- **`workspace_client.py`** — six new functions, incl. `resolve_location_for_channel(team_id, channel_id)` with a three-branch contract: bound → return; single workspace location → auto-bind silently; else → `None` (caller prompts).
- **`oauth.SCOPES`** — adds `chat:write.public`.
- **Slash command** — resolves location before posting; unbound channels get an ephemeral prompt (default-office button + static_select over workspace locations).
- **`/lunch_message` scheduler** — fails loudly on unbound channels (can't prompt a human).
- **Action handlers** — `CHANNEL_LOC_USE_DEFAULT` / `CHANNEL_LOC_PICK` persist the binding via `bind_channel_location`, then post the poll.
- **Read-site migration** — `polls.py` seed + `slack_actions.py` external_select now go through the resolver. Static test asserts zero remaining direct reads of `workspace['location']` outside `workspace_client.py`.

## Out of scope
- Creating new offices from the prompt (only selecting among existing).
- Admin UX for editing/removing bindings.
- Dropping the legacy `workspaces.location` column.
- Slack app manifest file edits (scope added in `oauth.py`; update manifest separately if applicable).

## Test plan
- [x] `pytest -q` → 223 passed, 4 skipped (local Postgres on :5432)
- [x] 15 new tests in `tests/test_channel_location_binding.py` cover migration, RLS, resolver three-branch contract, and binding persistence
- [ ] Manual: install in a test workspace, verify `chat:write.public` appears in granted scopes
- [ ] Manual: trigger `/lunch` in a new public channel without inviting the bot → prompt appears → choose default → poll posts
- [ ] Manual: second invocation in same channel → no prompt, poll posts immediately
- [ ] Manual: scheduler endpoint on unbound channel returns 400

Planning artifacts: `.planning/quick/260415-p4t-add-chat-write-public-scope-and-per-chan/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)